### PR TITLE
feat: add beacon client connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ const walletClient = createWalletClient({
 const sdk = new SSVSDK({
   publicClient,
   walletClient,
+  extendedConfig: {
+    beacon: {
+      endpoint: 'https://your-beacon-node.example',
+    },
+  },
 });
 ```
 
@@ -89,6 +94,18 @@ await sdk.utils.writeKeysharesFile({
   ownerAddress: 'your_wallet_address',
   nonce,
 });
+
+// Read normalized beacon validator state
+const validator = await sdk.api.getBeaconValidatorState({
+  validatorId: '0xvalidator_public_key',
+});
+
+// Wait for a validator to become active
+await sdk.api.waitForBeaconValidatorActivation({
+  validatorId: '0xvalidator_public_key',
+  pollIntervalMs: 12_000,
+  timeoutMs: 30 * 60 * 1000,
+});
 ```
 
 ### API Compatibility Notes
@@ -109,6 +126,8 @@ Snapshot-aware SDK read methods return the queried data together with the subgra
 `sdk.api.toSolidityCluster` is no longer part of the public subgraph API. The internal utility `toSolidityCluster(...)` in `utils/cluster` still exists for converting cluster data into the Solidity struct shape used by contract calls.
 
 `sdk.utils.writeKeysharesFile(...)` is a Node.js utility and relies on filesystem access.
+
+Beacon validator helpers require `extendedConfig.beacon.endpoint` to be configured. `sdk.api.getBeaconValidatorState(...)` and `sdk.api.getBeaconValidatorStates(...)` return normalized beacon validator data, and `sdk.api.waitForBeaconValidatorActivation(...)` can be used to poll until a validator becomes active.
 
 ### Cluster Management
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ const sdk = new SSVSDK({
   walletClient,
   extendedConfig: {
     beacon: {
+      // Optional — only needed for the beacon validator methods below.
       endpoint: 'https://your-beacon-node.example',
     },
   },
@@ -105,6 +106,8 @@ await sdk.api.waitForBeaconValidatorActivation({
   validatorId: '0xvalidator_public_key',
   pollIntervalMs: 12_000,
   timeoutMs: 30 * 60 * 1000,
+  // failOnNotFound: true,     // fail fast instead of treating "not found" as "not yet active"
+  // requestTimeoutMs: 10_000, // per-attempt timeout, independent of pollIntervalMs (defaults to 10s)
 });
 ```
 
@@ -127,7 +130,7 @@ Snapshot-aware SDK read methods return the queried data together with the subgra
 
 `sdk.utils.writeKeysharesFile(...)` is a Node.js utility and relies on filesystem access.
 
-Beacon validator helpers require `extendedConfig.beacon.endpoint` to be configured. `sdk.api.getBeaconValidatorState(...)` and `sdk.api.getBeaconValidatorStates(...)` return normalized beacon validator data, and `sdk.api.waitForBeaconValidatorActivation(...)` can be used to poll until a validator becomes active.
+Beacon validator helpers require `extendedConfig.beacon.endpoint` to be configured; the SDK works normally without it otherwise. `sdk.api.getBeaconValidatorState(...)` and `sdk.api.getBeaconValidatorStates(...)` return normalized beacon validator data, and `sdk.api.waitForBeaconValidatorActivation(...)` polls until a validator becomes active — its `requestTimeoutMs` option (default `10_000`) bounds each individual poll attempt independently of `pollIntervalMs`, and `failOnNotFound` (default `false`) controls whether a not-yet-visible validator fails fast or keeps polling. Failures surface as `BeaconHttpError` (carries the HTTP `status`; retried automatically for `408`/`429`/`5xx`, thrown immediately for other statuses) or `BeaconValidationError` (a malformed or unexpected response; always thrown immediately, never retried). `sdk.api.getBeaconValidator(...)` and `sdk.api.getBeaconValidators(...)` are lower-level reads that only validate the response envelope, not each validator's field-level shape — prefer the `...State`/`...States` variants unless you specifically need the raw shape. `sdk.api.getBeaconValidatorLifecycleStage(...)` derives a simplified lifecycle stage (`pending`/`active`/`exited`/`withdrawal_ready`/`withdrawn`) from a normalized status.
 
 ### Cluster Management
 

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1767,6 +1767,25 @@ describe('Beacon API', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('throws immediately on a non-http(s) endpoint scheme instead of retrying until timeout', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('ftp://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: ftp://beacon.example',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('throws immediately on a malformed response instead of retrying until timeout', async () => {
     vi.useFakeTimers();
 

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1748,6 +1748,48 @@ describe('Beacon API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces the real HTTP error even when cancelling the response body itself rejects', async () => {
+    const rejectingBody = {
+      cancel: vi.fn().mockRejectedValue(new Error('cancel-failed')),
+    };
+    const response = new Response(null, { status: 401 });
+    Object.defineProperty(response, 'body', { value: rejectingBody });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API request failed for getBeaconValidator with status 401',
+    );
+  });
+
+  it('does not retry a permanent HTTP error just because cancelling its body rejects', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation(() => {
+      const rejectingBody = {
+        cancel: vi.fn().mockRejectedValue(new Error('cancel-failed')),
+      };
+      const response = new Response(null, { status: 401 });
+      Object.defineProperty(response, 'body', { value: rejectingBody });
+      return Promise.resolve(response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon API request failed for getBeaconValidator with status 401',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('throws immediately on a malformed endpoint instead of retrying until timeout', async () => {
     vi.useFakeTimers();
 
@@ -1784,6 +1826,46 @@ describe('Beacon API', () => {
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws immediately on an endpoint carrying credentials instead of retrying until timeout', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://user:pass@beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: https://user:pass@beacon.example',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not retry a Fetch-spec-blocked port, but still retries other fetch-level TypeErrors', async () => {
+    vi.useFakeTimers();
+
+    const badPortError = new TypeError('fetch failed');
+    (badPortError as unknown as { cause?: unknown }).cause = new Error(
+      'bad port',
+    );
+    const fetchMock = vi.fn().mockRejectedValue(badPortError);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('http://beacon.example:25', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow('fetch failed');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('throws immediately on a malformed response instead of retrying until timeout', async () => {

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1803,7 +1803,7 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       }),
     ).rejects.toThrow(
-      'Invalid beacon endpoint for waitForBeaconValidatorActivation: not-a-valid-url',
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: (unparseable endpoint omitted to avoid leaking embedded credentials)',
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
@@ -1868,6 +1868,30 @@ describe('Beacon API', () => {
 
     await expect(promise).rejects.toThrow(BeaconValidationError);
     await expect(promise).rejects.not.toThrow(/super-secret-123/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not leak a credential that is visible in the raw string but makes the endpoint unparseable', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Invalid because the host is missing after '@', not because the
+    // credential syntax itself is malformed — 'super-secret' is still
+    // plainly visible in the raw string despite new URL() rejecting it.
+    const promise = waitForBeaconValidatorActivation(
+      'https://user:super-secret@',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+
+    await expect(promise).rejects.toThrow(BeaconValidationError);
+    await expect(promise).rejects.not.toThrow(/super-secret/);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -86,6 +86,21 @@ describe('Beacon API', () => {
     expect(validator?.index).toBe('12');
   });
 
+  it('rejects an empty or blank validatorId instead of requesting the unfiltered list', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '' }),
+    ).rejects.toThrow('getBeaconValidator requires a non-empty validatorId');
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '   ' }),
+    ).rejects.toThrow('getBeaconValidator requires a non-empty validatorId');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('constructs bound beacon API methods', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -578,7 +593,7 @@ describe('Beacon API', () => {
     ]);
   });
 
-  it('returns null entries for a batch not-found response', async () => {
+  it('throws when a batch validator request returns 404', async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
@@ -586,7 +601,9 @@ describe('Beacon API', () => {
       getBeaconValidatorStates('https://beacon.example', {
         validatorIds: ['1', '2'],
       }),
-    ).resolves.toEqual([null, null]);
+    ).rejects.toThrow(
+      'Beacon API request failed for getBeaconValidators with status 404',
+    );
   });
 
   it('throws a clear error when single validator response is missing data', async () => {
@@ -719,6 +736,72 @@ describe('Beacon API', () => {
 
     await activationExpectation;
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries after a transient fetch error while waiting for activation', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts a request that stalls past its remaining budget instead of hanging past timeoutMs', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(init.signal!.reason);
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 2_500,
+      },
+    );
+    const activationExpectation = expect(activationPromise).rejects.toThrow(
+      /time budget/,
+    );
+
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it('throws immediately in strict mode when a validator is not found', async () => {

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -824,6 +824,47 @@ describe('Beacon API', () => {
     ).rejects.toThrow('Beacon API returned an invalid response for getBeaconValidator');
   });
 
+  it('throws a clear error when the response data is explicitly null', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '1' }),
+    ).rejects.toThrow('Beacon API response is missing data for getBeaconValidator');
+  });
+
+  it('throws a clear error when batch response data is explicitly null', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example', { validatorIds: ['1'] }),
+    ).rejects.toThrow('Beacon API response is missing data for getBeaconValidators');
+  });
+
+  it('fails fast instead of polling to timeout when the response data is explicitly null', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon API response is missing data for getBeaconValidator',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('throws a clear error when the response body is not valid JSON', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('not json', { status: 200 }),
@@ -1054,6 +1095,52 @@ describe('Beacon API', () => {
       });
     });
 
+  it('does not abort a healthy response that takes longer than a short pollIntervalMs', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation(
+      (_url: string, init?: RequestInit) =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  data: createRawValidator({ status: 'active_ongoing' }),
+                }),
+                { status: 200 },
+              ),
+            );
+          }, 700);
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            reject(init.signal!.reason);
+          });
+        }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        // Shorter than the endpoint's real 700ms latency below — this used
+        // to make requestTimeoutMs (defaulting to pollIntervalMs) abort
+        // every attempt before a perfectly healthy response could arrive.
+        pollIntervalMs: 500,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(700);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('aborts a stalled first attempt well before a large overall deadline and retries', async () => {
     vi.useFakeTimers();
 
@@ -1075,7 +1162,9 @@ describe('Beacon API', () => {
       'https://beacon.example',
       {
         validatorId: '12',
-        pollIntervalMs: 1_000,
+        // Deliberately shorter than requestTimeoutMs's default, to prove the
+        // per-attempt budget is no longer tied to pollIntervalMs.
+        pollIntervalMs: 500,
         timeoutMs,
       },
     );
@@ -1086,10 +1175,10 @@ describe('Beacon API', () => {
       },
     );
 
-    // requestTimeoutMs defaults to pollIntervalMs (1s), so the stalled first
-    // attempt is aborted and retried almost immediately — not after the full
-    // 30-minute deadline.
-    await vi.advanceTimersByTimeAsync(2_000);
+    // requestTimeoutMs defaults to DEFAULT_REQUEST_TIMEOUT_MS (10s), so the
+    // stalled first attempt is aborted and retried well before the full
+    // 30-minute deadline — but not as fast as the (much shorter) pollIntervalMs.
+    await vi.advanceTimersByTimeAsync(11_000);
 
     await activationExpectation;
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -1107,6 +1196,10 @@ describe('Beacon API', () => {
         validatorId: '12',
         pollIntervalMs: 1_000,
         timeoutMs: 2_500,
+        // Explicit, since requestTimeoutMs no longer defaults to
+        // pollIntervalMs — this is what subdivides a short overall deadline
+        // into multiple bounded attempts.
+        requestTimeoutMs: 1_000,
       },
     );
     const activationExpectation = expect(activationPromise).rejects.toThrow(
@@ -1116,10 +1209,10 @@ describe('Beacon API', () => {
     await vi.advanceTimersByTimeAsync(2_500);
 
     await activationExpectation;
-    // requestTimeoutMs defaults to pollIntervalMs (1000ms): attempt 1 stalls
-    // for 1000ms then sleeps 1000ms, attempt 2 stalls for the remaining
-    // 500ms and lands exactly on the overall deadline — two bounded attempts
-    // total, never a single stall consuming the whole 2500ms budget.
+    // attempt 1 stalls for 1000ms then sleeps 1000ms, attempt 2 stalls for
+    // the remaining 500ms and lands exactly on the overall deadline — two
+    // bounded attempts total, never a single stall consuming the whole
+    // 2500ms budget.
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -121,6 +121,35 @@ describe('Beacon API', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each(['.', '..', '...'])(
+    'rejects a dot-segment validatorId (%s) instead of letting URL normalization redirect it',
+    async (dotSegment) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        getBeaconValidator('https://beacon.example', {
+          validatorId: dotSegment,
+        }),
+      ).rejects.toThrow(BeaconValidationError);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still allows an arbitrary non-matching validatorId, matching real server behavior', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await getBeaconValidator('https://beacon.example', {
+      validatorId: 'not-a-real-id-but-not-a-dot-segment-either',
+    });
+
+    expect(result).toBeNull();
+  });
+
   it('redacts a path-embedded api key from the endpoint error, keeping only origin + the beacon api path', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
@@ -405,6 +434,19 @@ describe('Beacon API', () => {
 
     await expect(promise).rejects.toThrow(BeaconValidationError);
     await expect(promise).rejects.not.toThrow(/super-secret/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a dot-segment validatorId in a batch call instead of letting URL normalization redirect it', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example', {
+        validatorIds: ['12', '..'],
+      }),
+    ).rejects.toThrow(BeaconValidationError);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1,5 +1,6 @@
 import {
   type BeaconValidator,
+  BeaconValidationError,
   getBeaconAPI,
   getBeaconValidatorLifecycleStage,
   getBeaconValidator,
@@ -834,6 +835,23 @@ describe('Beacon API', () => {
     ).rejects.toThrow('Beacon API returned invalid JSON for getBeaconValidator');
   });
 
+  it('propagates a body-read failure unchanged instead of treating it as invalid JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new TypeError('terminated')),
+    } as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const error: unknown = await getBeaconValidator('https://beacon.example', {
+      validatorId: '1',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).not.toBeInstanceOf(BeaconValidationError);
+    expect((error as Error).message).toBe('terminated');
+  });
+
   it('throws a clear error when batch validator response data is invalid', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -961,6 +979,45 @@ describe('Beacon API', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries after a body-read failure on an otherwise-successful response', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new TypeError('terminated')),
+      } as unknown as Response)
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1822,27 +1822,52 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       }),
     ).rejects.toThrow(
-      'Invalid beacon endpoint for waitForBeaconValidatorActivation: ftp://beacon.example',
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: ftp://beacon.example/eth/v1/beacon/states/head/validators',
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('throws immediately on an endpoint carrying credentials instead of retrying until timeout', async () => {
+  it('throws immediately on an endpoint carrying credentials instead of retrying until timeout, without leaking them', async () => {
     vi.useFakeTimers();
 
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
-    await expect(
-      waitForBeaconValidatorActivation('https://user:pass@beacon.example', {
+    const promise = waitForBeaconValidatorActivation(
+      'https://user:pass@beacon.example',
+      {
         validatorId: '12',
         pollIntervalMs: 1_000,
         timeoutMs: 5_000,
-      }),
-    ).rejects.toThrow(
-      'Invalid beacon endpoint for waitForBeaconValidatorActivation: https://user:pass@beacon.example',
+      },
     );
+
+    await expect(promise).rejects.toThrow(
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: https://beacon.example/eth/v1/beacon/states/head/validators',
+    );
+    await expect(promise).rejects.not.toThrow(/pass/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws immediately on an endpoint with query-string auth, without leaking the query string', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = waitForBeaconValidatorActivation(
+      'mailto:beacon.example?apiKey=super-secret-123',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+
+    await expect(promise).rejects.toThrow(BeaconValidationError);
+    await expect(promise).rejects.not.toThrow(/super-secret-123/);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -150,6 +150,30 @@ describe('Beacon API', () => {
     expect(result).toBeNull();
   });
 
+  it('rejects a non-string validatorId (a JS caller bypassing the TS types) without ever fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', {
+        validatorId: 123 as never,
+      }),
+    ).rejects.toThrow('getBeaconValidator requires validatorId to be a string');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a validatorId with an unpaired surrogate without ever fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '\uD800' }),
+    ).rejects.toThrow(/well-formed validatorId/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('redacts a path-embedded api key from the endpoint error, keeping only origin + the beacon api path', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
@@ -447,6 +471,21 @@ describe('Beacon API', () => {
         validatorIds: ['12', '..'],
       }),
     ).rejects.toThrow(BeaconValidationError);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string id in a batch call without ever fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example', {
+        validatorIds: ['12', 456 as never],
+      }),
+    ).rejects.toThrow(
+      'getBeaconValidators requires validatorId to be a string',
+    );
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -13,23 +13,27 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const FAR_FUTURE_EPOCH = '18446744073709551615';
 
-const createRawValidator = (
-  overrides?: {
-    index?: BeaconValidator['index'] | null;
-    balance?: BeaconValidator['balance'];
-    status?: BeaconValidator['status'];
-    validator?: Partial<BeaconValidator['validator']>;
-  },
-): BeaconValidator => ({
-  index: typeof overrides?.index === 'undefined' ? '12' : (overrides.index as never),
+// Beacon pubkeys are 0x-prefixed 48-byte (96 hex char) BLS keys; normalized
+// validation (mapBeaconValidatorState) now enforces this shape, so fixtures
+// must use valid-shaped keys wherever normalized reads are exercised.
+const VALID_PUBKEY_A = `0x${'a'.repeat(96)}`;
+const VALID_PUBKEY_B = `0x${'b'.repeat(96)}`;
+
+const createRawValidator = (overrides?: {
+  index?: BeaconValidator['index'] | null;
+  balance?: BeaconValidator['balance'];
+  status?: BeaconValidator['status'];
+  validator?: Partial<BeaconValidator['validator']>;
+}): BeaconValidator => ({
+  index:
+    typeof overrides?.index === 'undefined' ? '12' : (overrides.index as never),
   balance: overrides?.balance ?? '32000000000',
   status: overrides?.status ?? 'active_ongoing',
   validator: {
-    pubkey: overrides?.validator?.pubkey ?? '0xabc',
+    pubkey: overrides?.validator?.pubkey ?? VALID_PUBKEY_A,
     withdrawal_credentials:
       overrides?.validator?.withdrawal_credentials ?? '0xdef',
-    effective_balance:
-      overrides?.validator?.effective_balance ?? '32000000000',
+    effective_balance: overrides?.validator?.effective_balance ?? '32000000000',
     slashed: overrides?.validator?.slashed ?? false,
     activation_eligibility_epoch:
       typeof overrides?.validator?.activation_eligibility_epoch === 'undefined'
@@ -179,9 +183,11 @@ describe('Beacon API', () => {
   });
 
   it('passes an AbortSignal through on the batch GET path', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     const controller = new AbortController();
@@ -198,9 +204,11 @@ describe('Beacon API', () => {
   });
 
   it('passes an AbortSignal through on the batch POST path', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [] }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     const controller = new AbortController();
@@ -227,8 +235,14 @@ describe('Beacon API', () => {
       new Response(
         JSON.stringify({
           data: [
-            createRawValidator({ index: '5', validator: { pubkey: '0xaaa' } }),
-            createRawValidator({ index: '7', validator: { pubkey: '0xbbb' } }),
+            createRawValidator({
+              index: '5',
+              validator: { pubkey: VALID_PUBKEY_A },
+            }),
+            createRawValidator({
+              index: '7',
+              validator: { pubkey: VALID_PUBKEY_B },
+            }),
           ],
         }),
         { status: 200 },
@@ -244,9 +258,9 @@ describe('Beacon API', () => {
       'https://beacon.example/eth/v1/beacon/states/head/validators?id=5&id=7',
     );
     expect(states.map((state) => state?.publicKey)).toEqual([
-      '0xaaa',
-      '0xaaa',
-      '0xbbb',
+      VALID_PUBKEY_A,
+      VALID_PUBKEY_A,
+      VALID_PUBKEY_B,
     ]);
   });
 
@@ -333,7 +347,9 @@ describe('Beacon API', () => {
   });
 
   it('returns null when a beacon validator is not found', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -369,7 +385,7 @@ describe('Beacon API', () => {
     await expect(
       getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
     ).resolves.toEqual({
-      publicKey: '0xabc',
+      publicKey: VALID_PUBKEY_A,
       validatorIndex: 12,
       status: 'active',
       rawStatus: 'active_ongoing',
@@ -460,24 +476,29 @@ describe('Beacon API', () => {
     ['exited_slashed', 'exited'],
     ['withdrawal_possible', 'withdrawal_possible'],
     ['withdrawal_done', 'withdrawal_done'],
-  ] as const)('maps raw beacon status %s to normalized status %s', async (rawStatus, status) => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          data: createRawValidator({ status: rawStatus }),
-        }),
-        { status: 200 },
-      ),
-    );
-    vi.stubGlobal('fetch', fetchMock);
+  ] as const)(
+    'maps raw beacon status %s to normalized status %s',
+    async (rawStatus, status) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: rawStatus }),
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
 
-    await expect(
-      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
-    ).resolves.toMatchObject({
-      status,
-      rawStatus,
-    });
-  });
+      await expect(
+        getBeaconValidatorState('https://beacon.example', {
+          validatorId: '12',
+        }),
+      ).resolves.toMatchObject({
+        status,
+        rawStatus,
+      });
+    },
+  );
 
   it('rejects unknown validator statuses', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
@@ -495,6 +516,79 @@ describe('Beacon API', () => {
     ).rejects.toThrow(
       'Beacon API returned an invalid response for getBeaconValidatorState: unsupported status mystery_status',
     );
+  });
+
+  it('fails clearly when validator.pubkey is missing', async () => {
+    // createRawValidator's overrides fall back via ?? on undefined, so
+    // pubkey: undefined would silently resolve to the default valid key —
+    // omit the property entirely to genuinely simulate it being absent.
+    const rawValidator = createRawValidator();
+    const validatorWithoutPubkey: Record<string, unknown> = {
+      ...rawValidator.validator,
+    };
+    delete validatorWithoutPubkey.pubkey;
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: { ...rawValidator, validator: validatorWithoutPubkey },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: validator.pubkey must be a string',
+    );
+  });
+
+  it.each([
+    ['empty', ''],
+    ['non-hex characters', `0x${'g'.repeat(96)}`],
+    ['too short', `0x${'a'.repeat(95)}`],
+    ['too long', `0x${'a'.repeat(97)}`],
+    ['missing 0x prefix', 'a'.repeat(96)],
+  ] as const)(
+    'fails clearly when validator.pubkey is %s',
+    async (_label, pubkey) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ validator: { pubkey } }),
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        getBeaconValidatorState('https://beacon.example', {
+          validatorId: '12',
+        }),
+      ).rejects.toThrow(
+        'Beacon API returned an invalid response for getBeaconValidatorState: validator.pubkey must be a 0x-prefixed 48-byte hex string',
+      );
+    },
+  );
+
+  it('accepts a valid mixed-case pubkey', async () => {
+    const mixedCasePubkey = `0x${'AbCdEf0123456789'.repeat(6)}`;
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ validator: { pubkey: mixedCasePubkey } }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).resolves.toMatchObject({ publicKey: mixedCasePubkey });
   });
 
   it('fails clearly when validator.slashed is malformed', async () => {
@@ -529,16 +623,20 @@ describe('Beacon API', () => {
   ] as const)(
     'rejects a non-canonical balance value (%s)',
     async (_label, balance) => {
-      const fetchMock = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({ data: createRawValidator({ balance }) }),
-          { status: 200 },
-        ),
-      );
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: createRawValidator({ balance }) }),
+            { status: 200 },
+          ),
+        );
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
-        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+        getBeaconValidatorState('https://beacon.example', {
+          validatorId: '12',
+        }),
       ).rejects.toThrow(
         'Beacon API returned an invalid response for getBeaconValidatorState: balance must be a canonical non-negative integer string',
       );
@@ -570,16 +668,20 @@ describe('Beacon API', () => {
   ] as const)(
     'rejects a non-canonical validator index value (%s)',
     async (_label, index) => {
-      const fetchMock = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({ data: createRawValidator({ index }) }),
-          { status: 200 },
-        ),
-      );
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({ data: createRawValidator({ index }) }),
+            { status: 200 },
+          ),
+        );
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
-        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+        getBeaconValidatorState('https://beacon.example', {
+          validatorId: '12',
+        }),
       ).rejects.toThrow(
         'Beacon API returned an invalid response for getBeaconValidatorState: index must be a canonical non-negative integer string',
       );
@@ -589,7 +691,9 @@ describe('Beacon API', () => {
   it('throws instead of treating a validator index equal to the far-future sentinel as absent', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
-        JSON.stringify({ data: createRawValidator({ index: FAR_FUTURE_EPOCH }) }),
+        JSON.stringify({
+          data: createRawValidator({ index: FAR_FUTURE_EPOCH }),
+        }),
         { status: 200 },
       ),
     );
@@ -624,7 +728,9 @@ describe('Beacon API', () => {
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
-        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+        getBeaconValidatorState('https://beacon.example', {
+          validatorId: '12',
+        }),
       ).rejects.toThrow(
         'Beacon API returned an invalid response for getBeaconValidatorState: validator.exit_epoch must be a canonical non-negative integer string',
       );
@@ -671,7 +777,9 @@ describe('Beacon API', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
-      getBeaconValidatorState('https://beacon.example', { validatorId: '0xabc' }),
+      getBeaconValidatorState('https://beacon.example', {
+        validatorId: '0xabc',
+      }),
     ).resolves.toMatchObject({
       validatorIndex: null,
       activationEligibilityEpoch: null,
@@ -686,8 +794,14 @@ describe('Beacon API', () => {
       new Response(
         JSON.stringify({
           data: [
-            createRawValidator({ index: '2', validator: { pubkey: '0xbbb' } }),
-            createRawValidator({ index: '1', validator: { pubkey: '0xaaa' } }),
+            createRawValidator({
+              index: '2',
+              validator: { pubkey: VALID_PUBKEY_B },
+            }),
+            createRawValidator({
+              index: '1',
+              validator: { pubkey: VALID_PUBKEY_A },
+            }),
           ],
         }),
         { status: 200 },
@@ -697,11 +811,11 @@ describe('Beacon API', () => {
 
     await expect(
       getBeaconValidatorStates('https://beacon.example', {
-        validatorIds: ['0xaaa', 'missing', '2'],
+        validatorIds: [VALID_PUBKEY_A, 'missing', '2'],
       }),
     ).resolves.toEqual([
       {
-        publicKey: '0xaaa',
+        publicKey: VALID_PUBKEY_A,
         validatorIndex: 1,
         status: 'active',
         rawStatus: 'active_ongoing',
@@ -715,7 +829,7 @@ describe('Beacon API', () => {
       },
       null,
       {
-        publicKey: '0xbbb',
+        publicKey: VALID_PUBKEY_B,
         validatorIndex: 2,
         status: 'active',
         rawStatus: 'active_ongoing',
@@ -735,8 +849,14 @@ describe('Beacon API', () => {
       new Response(
         JSON.stringify({
           data: [
-            createRawValidator({ index: '2', validator: { pubkey: '0xbbb' } }),
-            createRawValidator({ index: '1', validator: { pubkey: '0xaaa' } }),
+            createRawValidator({
+              index: '2',
+              validator: { pubkey: VALID_PUBKEY_B },
+            }),
+            createRawValidator({
+              index: '1',
+              validator: { pubkey: VALID_PUBKEY_A },
+            }),
           ],
         }),
         { status: 200 },
@@ -748,7 +868,7 @@ describe('Beacon API', () => {
       { length: 60 },
       (_, index) => `missing-${index}-${'c'.repeat(120)}`,
     );
-    validatorIds[0] = '0xaaa';
+    validatorIds[0] = VALID_PUBKEY_A;
     validatorIds[59] = '2';
 
     const expected = Array.from({ length: 60 }, () => null) as Array<
@@ -756,7 +876,7 @@ describe('Beacon API', () => {
     >;
 
     expected[0] = {
-      publicKey: '0xaaa',
+      publicKey: VALID_PUBKEY_A,
       validatorIndex: 1,
       status: 'active',
       rawStatus: 'active_ongoing',
@@ -769,7 +889,7 @@ describe('Beacon API', () => {
       withdrawableEpoch: 4,
     };
     expected[59] = {
-      publicKey: '0xbbb',
+      publicKey: VALID_PUBKEY_B,
       validatorIndex: 2,
       status: 'active',
       rawStatus: 'active_ongoing',
@@ -808,14 +928,14 @@ describe('Beacon API', () => {
             createRawValidator({
               index: '1',
               validator: {
-                pubkey: '0xaaa',
+                pubkey: VALID_PUBKEY_A,
                 exit_epoch: FAR_FUTURE_EPOCH,
               },
             }),
             createRawValidator({
               index: '2',
               validator: {
-                pubkey: '0xbbb',
+                pubkey: VALID_PUBKEY_B,
                 withdrawable_epoch: FAR_FUTURE_EPOCH,
               },
             }),
@@ -828,16 +948,16 @@ describe('Beacon API', () => {
 
     await expect(
       getBeaconValidatorStates('https://beacon.example', {
-        validatorIds: ['0xaaa', '0xbbb'],
+        validatorIds: [VALID_PUBKEY_A, VALID_PUBKEY_B],
       }),
     ).resolves.toEqual([
       expect.objectContaining({
-        publicKey: '0xaaa',
+        publicKey: VALID_PUBKEY_A,
         exitEpoch: null,
         withdrawableEpoch: 4,
       }),
       expect.objectContaining({
-        publicKey: '0xbbb',
+        publicKey: VALID_PUBKEY_B,
         exitEpoch: 3,
         withdrawableEpoch: null,
       }),
@@ -845,7 +965,9 @@ describe('Beacon API', () => {
   });
 
   it('throws when a batch validator request returns 404', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -858,42 +980,54 @@ describe('Beacon API', () => {
   });
 
   it('throws a clear error when single validator response is missing data', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({}), { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       getBeaconValidator('https://beacon.example', { validatorId: '1' }),
-    ).rejects.toThrow('Beacon API returned an invalid response for getBeaconValidator');
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidator',
+    );
   });
 
   it('throws a clear error when the response data is explicitly null', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: null }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: null }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       getBeaconValidator('https://beacon.example', { validatorId: '1' }),
-    ).rejects.toThrow('Beacon API response is missing data for getBeaconValidator');
+    ).rejects.toThrow(
+      'Beacon API response is missing data for getBeaconValidator',
+    );
   });
 
   it('throws a clear error when batch response data is explicitly null', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: null }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: null }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       getBeaconValidators('https://beacon.example', { validatorIds: ['1'] }),
-    ).rejects.toThrow('Beacon API response is missing data for getBeaconValidators');
+    ).rejects.toThrow(
+      'Beacon API response is missing data for getBeaconValidators',
+    );
   });
 
   it('fails fast instead of polling to timeout when the response data is explicitly null', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: null }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: null }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -910,14 +1044,16 @@ describe('Beacon API', () => {
   });
 
   it('throws a clear error when the response body is not valid JSON', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response('not json', { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('not json', { status: 200 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       getBeaconValidator('https://beacon.example', { validatorId: '1' }),
-    ).rejects.toThrow('Beacon API returned invalid JSON for getBeaconValidator');
+    ).rejects.toThrow(
+      'Beacon API returned invalid JSON for getBeaconValidator',
+    );
   });
 
   it('propagates a body-read failure unchanged instead of treating it as invalid JSON', async () => {
@@ -975,16 +1111,20 @@ describe('Beacon API', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
-      getBeaconValidatorStates('https://beacon.example', { validatorIds: ['1'] }),
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds: ['1'],
+      }),
     ).rejects.toThrow(
       'Beacon API returned an invalid response for getBeaconValidatorStates: validator.effective_balance must be a string',
     );
   });
 
   it('throws a clear error when a single validator entry is not an object', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: 'oops' }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: 'oops' }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -995,13 +1135,17 @@ describe('Beacon API', () => {
   });
 
   it('throws a clear error when a batch validator entry is not an object', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(JSON.stringify({ data: [42] }), { status: 200 }),
-    );
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [42] }), { status: 200 }),
+      );
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
-      getBeaconValidatorStates('https://beacon.example', { validatorIds: ['1'] }),
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds: ['1'],
+      }),
     ).rejects.toThrow(
       'Beacon API returned an invalid response for getBeaconValidatorStates',
     );
@@ -1133,7 +1277,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1168,7 +1314,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1203,7 +1351,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1238,7 +1388,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1277,7 +1429,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1330,7 +1484,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1368,12 +1524,12 @@ describe('Beacon API', () => {
         timeoutMs,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject(
-      {
-        status: 'active',
-        rawStatus: 'active_ongoing',
-      },
-    );
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
 
     // requestTimeoutMs defaults to DEFAULT_REQUEST_TIMEOUT_MS (10s), so the
     // stalled first attempt is aborted and retried well before the full
@@ -1402,9 +1558,8 @@ describe('Beacon API', () => {
         requestTimeoutMs: 1_000,
       },
     );
-    const activationExpectation = expect(activationPromise).rejects.toThrow(
-      /time budget/,
-    );
+    const activationExpectation =
+      expect(activationPromise).rejects.toThrow(/time budget/);
 
     await vi.advanceTimersByTimeAsync(2_500);
 
@@ -1417,7 +1572,9 @@ describe('Beacon API', () => {
   });
 
   it('throws immediately in strict mode when a validator is not found', async () => {
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -1437,7 +1594,9 @@ describe('Beacon API', () => {
   it('throws immediately on a non-retryable HTTP status instead of retrying until timeout', async () => {
     vi.useFakeTimers();
 
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 401 }));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
@@ -1482,7 +1641,9 @@ describe('Beacon API', () => {
   it('preserves the last retryable error when repeated failures exhaust the deadline', async () => {
     vi.useFakeTimers();
 
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 503 }));
     vi.stubGlobal('fetch', fetchMock);
 
     const activationPromise = waitForBeaconValidatorActivation(
@@ -1540,7 +1701,9 @@ describe('Beacon API', () => {
         timeoutMs: 5_000,
       },
     );
-    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+    const activationExpectation = expect(
+      activationPromise,
+    ).resolves.toMatchObject({
       status: 'active',
       rawStatus: 'active_ongoing',
     });
@@ -1586,7 +1749,9 @@ describe('Beacon API', () => {
   it('times out in default mode after repeated not-found responses', async () => {
     vi.useFakeTimers();
 
-    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 }));
     vi.stubGlobal('fetch', fetchMock);
 
     const activationPromise = waitForBeaconValidatorActivation(

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -106,6 +106,41 @@ describe('Beacon API', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects a credentialed endpoint before fetching, without leaking the credential', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = getBeaconValidator(
+      'https://user:super-secret@beacon.example',
+      { validatorId: '12' },
+    );
+
+    await expect(promise).rejects.toThrow(BeaconValidationError);
+    await expect(promise).rejects.not.toThrow(/super-secret/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('redacts a path-embedded api key from the endpoint error, keeping only origin + the beacon api path', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    // A provider-style endpoint with an api key in the path (Infura's
+    // '/v3/<key>' shape), plus credentials, so both need to be excluded.
+    const promise = getBeaconValidator(
+      'https://user:pass@provider.example/v3/super-secret-api-key',
+      { validatorId: '12' },
+    );
+
+    await expect(promise).rejects.toThrow(
+      'Invalid beacon endpoint for getBeaconValidator: https://provider.example/eth/v1/beacon/states/head/validators',
+    );
+    await expect(promise).rejects.not.toThrow(/super-secret-api-key/);
+    await expect(promise).rejects.not.toThrow(/pass/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('constructs bound beacon API methods', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -355,6 +390,21 @@ describe('Beacon API', () => {
     ).rejects.toThrow(
       'getBeaconValidators requires every validatorId to be non-empty',
     );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a credentialed endpoint before fetching a batch, without leaking the credential', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const promise = getBeaconValidators(
+      'https://user:super-secret@beacon.example',
+      { validatorIds: ['12'] },
+    );
+
+    await expect(promise).rejects.toThrow(BeaconValidationError);
+    await expect(promise).rejects.not.toThrow(/super-secret/);
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1922,6 +1922,38 @@ describe('Beacon API', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['scheme typo', 'htttps://beacon.example/s3cr3t/'],
+    [
+      'non-special scheme with embedded credentials',
+      'admin:s3cr3t@beacon.example',
+    ],
+  ])(
+    'reports the generic placeholder, not a confusing "null/..." string, for an opaque-origin endpoint (%s)',
+    async (_label, endpoint) => {
+      vi.useFakeTimers();
+
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      // These parse successfully (new URL() doesn't throw) but as an
+      // opaque-origin URL, where url.origin serializes to the literal
+      // string 'null' rather than a real origin.
+      const promise = waitForBeaconValidatorActivation(endpoint, {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      });
+
+      await expect(promise).rejects.toThrow(
+        'Invalid beacon endpoint for waitForBeaconValidatorActivation: (unparseable endpoint omitted to avoid leaking embedded credentials)',
+      );
+      await expect(promise).rejects.not.toThrow(/s3cr3t/);
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
   it('does not leak a credential that is visible in the raw string but makes the endpoint unparseable', async () => {
     vi.useFakeTimers();
 

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -121,7 +121,7 @@ describe('Beacon API', () => {
     expect(fetchMock.mock.calls[0]).toHaveLength(1);
   });
 
-  it('uses GET for beacon validator batches when the URL stays short enough', async () => {
+  it('uses GET for up to 64 deduplicated validator ids with a short URL', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -132,7 +132,7 @@ describe('Beacon API', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
-    const validatorIds = Array.from({ length: 100 }, (_, index) => `${index}`);
+    const validatorIds = Array.from({ length: 64 }, (_, index) => `${index}`);
 
     await getBeaconValidators('https://beacon.example/api', {
       validatorIds,
@@ -144,6 +144,80 @@ describe('Beacon API', () => {
         .join('&')}`,
     );
     expect(fetchMock.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('uses POST once the deduplicated id count exceeds 64, even with a short URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // The Beacon API GET endpoint caps id[] at 64 items (maxItems: 64,
+    // documented 414 above that) regardless of URL length.
+    const validatorIds = Array.from({ length: 65 }, (_, index) => `${index}`);
+
+    await getBeaconValidators('https://beacon.example/api', {
+      validatorIds,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/api/eth/v1/beacon/states/head/validators',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ids: validatorIds }),
+      },
+    );
+  });
+
+  it('deduplicates transport ids while preserving repeated aligned outputs', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            createRawValidator({ index: '5', validator: { pubkey: '0xaaa' } }),
+            createRawValidator({ index: '7', validator: { pubkey: '0xbbb' } }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const states = await getBeaconValidatorStates('https://beacon.example', {
+      validatorIds: ['5', '5', '7'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators?id=5&id=7',
+    );
+    expect(states.map((state) => state?.publicKey)).toEqual([
+      '0xaaa',
+      '0xaaa',
+      '0xbbb',
+    ]);
+  });
+
+  it('rejects a blank validatorId in a batch request instead of sending it', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example', {
+        validatorIds: ['1', '   '],
+      }),
+    ).rejects.toThrow(
+      'getBeaconValidators requires every validatorId to be non-empty',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('uses POST for beacon validator batches when the GET URL would be too long', async () => {
@@ -400,6 +474,138 @@ describe('Beacon API', () => {
     );
   });
 
+  it.each([
+    ['empty string', ''],
+    ['whitespace', '   '],
+    ['negative', '-1'],
+    ['explicitly signed', '+1'],
+    ['hexadecimal', '0x10'],
+    ['leading zero', '007'],
+  ] as const)(
+    'rejects a non-canonical balance value (%s)',
+    async (_label, balance) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ data: createRawValidator({ balance }) }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+      ).rejects.toThrow(
+        'Beacon API returned an invalid response for getBeaconValidatorState: balance must be a canonical non-negative integer string',
+      );
+    },
+  );
+
+  it('rejects a balance value exceeding the uint64 range', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ balance: '18446744073709551616' }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: balance exceeds the uint64 range',
+    );
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['negative', '-1'],
+    ['hexadecimal', '0x1'],
+  ] as const)(
+    'rejects a non-canonical validator index value (%s)',
+    async (_label, index) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ data: createRawValidator({ index }) }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+      ).rejects.toThrow(
+        'Beacon API returned an invalid response for getBeaconValidatorState: index must be a canonical non-negative integer string',
+      );
+    },
+  );
+
+  it('throws instead of treating a validator index equal to the far-future sentinel as absent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ data: createRawValidator({ index: FAR_FUTURE_EPOCH }) }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    // index has no far-future-sentinel semantics (unlike the epoch fields),
+    // so a value that large is just out of range, not "not yet set".
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: index exceeds MAX_SAFE_INTEGER',
+    );
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['negative', '-1'],
+    ['hexadecimal', '0x3'],
+  ] as const)(
+    'rejects a non-canonical exit_epoch value (%s)',
+    async (_label, exitEpoch) => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({
+              validator: { exit_epoch: exitEpoch as never },
+            }),
+          }),
+          { status: 200 },
+        ),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+      ).rejects.toThrow(
+        'Beacon API returned an invalid response for getBeaconValidatorState: validator.exit_epoch must be a canonical non-negative integer string',
+      );
+    },
+  );
+
+  it('rejects an epoch value exceeding the uint64 range', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({
+            validator: { exit_epoch: '18446744073709551616' as never },
+          }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: validator.exit_epoch exceeds the uint64 range',
+    );
+  });
+
   it('converts optional numeric fields to null when unavailable', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -617,6 +823,17 @@ describe('Beacon API', () => {
     ).rejects.toThrow('Beacon API returned an invalid response for getBeaconValidator');
   });
 
+  it('throws a clear error when the response body is not valid JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('not json', { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '1' }),
+    ).rejects.toThrow('Beacon API returned invalid JSON for getBeaconValidator');
+  });
+
   it('throws a clear error when batch validator response data is invalid', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -773,17 +990,58 @@ describe('Beacon API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('aborts a request that stalls past its remaining budget instead of hanging past timeoutMs', async () => {
+  const stallUntilAborted = (_url: string, init?: RequestInit) =>
+    new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(init.signal!.reason);
+      });
+    });
+
+  it('aborts a stalled first attempt well before a large overall deadline and retries', async () => {
     vi.useFakeTimers();
 
-    const fetchMock = vi.fn().mockImplementation(
-      (_url: string, init?: RequestInit) =>
-        new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener('abort', () => {
-            reject(init.signal!.reason);
-          });
-        }),
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(stallUntilAborted)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const timeoutMs = 30 * 60 * 1_000; // 30 minutes
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs,
+      },
     );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject(
+      {
+        status: 'active',
+        rawStatus: 'active_ongoing',
+      },
+    );
+
+    // requestTimeoutMs defaults to pollIntervalMs (1s), so the stalled first
+    // attempt is aborted and retried almost immediately — not after the full
+    // 30-minute deadline.
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps retrying across a sequence of stalled requests until the overall deadline elapses', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation(stallUntilAborted);
     vi.stubGlobal('fetch', fetchMock);
 
     const activationPromise = waitForBeaconValidatorActivation(
@@ -801,7 +1059,11 @@ describe('Beacon API', () => {
     await vi.advanceTimersByTimeAsync(2_500);
 
     await activationExpectation;
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // requestTimeoutMs defaults to pollIntervalMs (1000ms): attempt 1 stalls
+    // for 1000ms then sleeps 1000ms, attempt 2 stalls for the remaining
+    // 500ms and lands exactly on the overall deadline — two bounded attempts
+    // total, never a single stall consuming the whole 2500ms budget.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('throws immediately in strict mode when a validator is not found', async () => {
@@ -820,6 +1082,74 @@ describe('Beacon API', () => {
     );
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws immediately on a non-retryable HTTP status instead of retrying until timeout', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon API request failed for getBeaconValidator with status 401',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws immediately on a malformed response instead of retrying until timeout', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ status: 'mystery_status' as never }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: unsupported status mystery_status',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the last retryable error when repeated failures exhaust the deadline', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 2_500,
+      },
+    );
+    const activationExpectation = expect(activationPromise).rejects.toThrow(
+      'Beacon API request failed for getBeaconValidator with status 503',
+    );
+
+    await vi.advanceTimersByTimeAsync(2_500);
+
+    await activationExpectation;
   });
 
   it('waits while pending validators contain far-future epoch sentinels', async () => {

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1748,6 +1748,25 @@ describe('Beacon API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('throws immediately on a malformed endpoint instead of retrying until timeout', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('not-a-valid-url', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Invalid beacon endpoint for waitForBeaconValidatorActivation: not-a-valid-url',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('throws immediately on a malformed response instead of retrying until timeout', async () => {
     vi.useFakeTimers();
 

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -178,6 +178,50 @@ describe('Beacon API', () => {
     );
   });
 
+  it('passes an AbortSignal through on the batch GET path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const controller = new AbortController();
+
+    await getBeaconValidators('https://beacon.example', {
+      validatorIds: ['1', '2'],
+      signal: controller.signal,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators?id=1&id=2',
+      { signal: controller.signal },
+    );
+  });
+
+  it('passes an AbortSignal through on the batch POST path', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const controller = new AbortController();
+    const validatorIds = Array.from({ length: 65 }, (_, index) => `${index}`);
+
+    await getBeaconValidators('https://beacon.example', {
+      validatorIds,
+      signal: controller.signal,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: validatorIds }),
+        signal: controller.signal,
+      },
+    );
+  });
+
   it('deduplicates transport ids while preserving repeated aligned outputs', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -439,7 +483,7 @@ describe('Beacon API', () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
-          data: createRawValidator({ status: 'mystery_status' as never }),
+          data: createRawValidator({ status: 'mystery_status' }),
         }),
         { status: 200 },
       ),
@@ -937,6 +981,127 @@ describe('Beacon API', () => {
     );
   });
 
+  it('throws a clear error when a single validator entry is not an object', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: 'oops' }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '1' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState',
+    );
+  });
+
+  it('throws a clear error when a batch validator entry is not an object', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [42] }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', { validatorIds: ['1'] }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorStates',
+    );
+  });
+
+  it('throws a clear error when a validator entry is missing the nested validator object', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: { index: '1', balance: '1', status: 'active_ongoing' },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '1' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: validator must be an object',
+    );
+  });
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['non-integer', 1.5],
+  ] as const)(
+    'rejects a %s pollIntervalMs before making any request',
+    async (_label, pollIntervalMs) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        waitForBeaconValidatorActivation('https://beacon.example', {
+          validatorId: '12',
+          pollIntervalMs,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow('expected a positive integer number of milliseconds');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['non-integer', 1.5],
+  ] as const)(
+    'rejects a %s timeoutMs before making any request',
+    async (_label, timeoutMs) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        waitForBeaconValidatorActivation('https://beacon.example', {
+          validatorId: '12',
+          pollIntervalMs: 1_000,
+          timeoutMs,
+        }),
+      ).rejects.toThrow('expected a positive integer number of milliseconds');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a non-positive requestTimeoutMs before making any request', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+        requestTimeoutMs: 0,
+      }),
+    ).rejects.toThrow('expected a positive integer number of milliseconds');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects immediately when the endpoint is missing, without ever polling', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation(undefined, {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon endpoint is not configured. Provide extendedConfig.beacon.endpoint in SDK config.',
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('waits for a validator to become active', async () => {
     vi.useFakeTimers();
 
@@ -1014,12 +1179,47 @@ describe('Beacon API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('retries after a transient fetch error while waiting for activation', async () => {
+  it('retries after a retryable HTTP status (503) while waiting for activation', async () => {
     vi.useFakeTimers();
 
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries after fetch() itself rejects (e.g. a genuine network failure)', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
@@ -1259,7 +1459,7 @@ describe('Beacon API', () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
-          data: createRawValidator({ status: 'mystery_status' as never }),
+          data: createRawValidator({ status: 'mystery_status' }),
         }),
         { status: 200 },
       ),

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -106,7 +106,7 @@ describe('Beacon API', () => {
     expect(fetchMock.mock.calls[0]).toHaveLength(1);
   });
 
-  it('requests batch beacon validators with repeated id query parameters', async () => {
+  it('uses GET for beacon validator batches when the URL stays short enough', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -117,14 +117,50 @@ describe('Beacon API', () => {
     );
     vi.stubGlobal('fetch', fetchMock);
 
+    const validatorIds = Array.from({ length: 100 }, (_, index) => `${index}`);
+
     await getBeaconValidators('https://beacon.example/api', {
-      validatorIds: ['0xabc/1', '2'],
+      validatorIds,
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'https://beacon.example/api/eth/v1/beacon/states/head/validators?id=0xabc%2F1&id=2',
+      `https://beacon.example/api/eth/v1/beacon/states/head/validators?${validatorIds
+        .map((validatorId) => `id=${validatorId}`)
+        .join('&')}`,
     );
     expect(fetchMock.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('uses POST for beacon validator batches when the GET URL would be too long', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validatorIds = Array.from(
+      { length: 60 },
+      (_, index) => `0x${String(index).padStart(2, '0')}${'a'.repeat(120)}`,
+    );
+
+    await getBeaconValidators('https://beacon.example/api', {
+      validatorIds,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/api/eth/v1/beacon/states/head/validators',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ids: validatorIds }),
+      },
+    );
   });
 
   it('returns an empty validator batch without calling fetch', async () => {
@@ -147,6 +183,19 @@ describe('Beacon API', () => {
     ).resolves.toEqual([]);
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws the same missing endpoint error for empty batch validator states as single validator state reads', async () => {
+    const expectedError =
+      'Beacon endpoint is not configured. Provide extendedConfig.beacon.endpoint in SDK config.';
+
+    await expect(
+      getBeaconAPI().getBeaconValidatorState({ validatorId: '1' }),
+    ).rejects.toThrow(expectedError);
+
+    await expect(
+      getBeaconAPI().getBeaconValidatorStates({ validatorIds: [] }),
+    ).rejects.toThrow(expectedError);
   });
 
   it('returns null when a beacon validator is not found', async () => {
@@ -415,6 +464,76 @@ describe('Beacon API', () => {
     ]);
   });
 
+  it('preserves output ordering and nulls for large POST batch validator state lookups', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            createRawValidator({ index: '2', validator: { pubkey: '0xbbb' } }),
+            createRawValidator({ index: '1', validator: { pubkey: '0xaaa' } }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validatorIds = Array.from(
+      { length: 60 },
+      (_, index) => `missing-${index}-${'c'.repeat(120)}`,
+    );
+    validatorIds[0] = '0xaaa';
+    validatorIds[59] = '2';
+
+    const expected = Array.from({ length: 60 }, () => null) as Array<
+      Awaited<ReturnType<typeof getBeaconValidatorStates>>[number]
+    >;
+
+    expected[0] = {
+      publicKey: '0xaaa',
+      validatorIndex: 1,
+      status: 'active',
+      rawStatus: 'active_ongoing',
+      balanceGwei: 32000000000n,
+      effectiveBalanceGwei: 32000000000n,
+      slashed: false,
+      activationEligibilityEpoch: 1,
+      activationEpoch: 2,
+      exitEpoch: 3,
+      withdrawableEpoch: 4,
+    };
+    expected[59] = {
+      publicKey: '0xbbb',
+      validatorIndex: 2,
+      status: 'active',
+      rawStatus: 'active_ongoing',
+      balanceGwei: 32000000000n,
+      effectiveBalanceGwei: 32000000000n,
+      slashed: false,
+      activationEligibilityEpoch: 1,
+      activationEpoch: 2,
+      exitEpoch: 3,
+      withdrawableEpoch: 4,
+    };
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds,
+      }),
+    ).resolves.toEqual(expected);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ ids: validatorIds }),
+      },
+    );
+  });
+
   it('maps far-future epoch sentinels to null in batch normalization', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -567,6 +686,59 @@ describe('Beacon API', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps retrying by default when a validator is initially not found', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: 'missing',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws immediately in strict mode when a validator is not found', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: 'missing',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+        failOnNotFound: true,
+      }),
+    ).rejects.toThrow(
+      'Beacon validator missing was not found while waiting for activation',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('waits while pending validators contain far-future epoch sentinels', async () => {
     vi.useFakeTimers();
 
@@ -641,6 +813,29 @@ describe('Beacon API', () => {
     );
     const activationExpectation = expect(activationPromise).rejects.toThrow(
       'Timed out waiting for beacon validator activation for 12 after 2500ms; last observed state: pending (pending_queued)',
+    );
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await activationExpectation;
+  });
+
+  it('times out in default mode after repeated not-found responses', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: 'missing',
+        pollIntervalMs: 1_000,
+        timeoutMs: 2_500,
+      },
+    );
+    const activationExpectation = expect(activationPromise).rejects.toThrow(
+      'Timed out waiting for beacon validator activation for missing after 2500ms; last observed state: not found',
     );
 
     await vi.advanceTimersByTimeAsync(3_000);

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -230,6 +230,67 @@ describe('Beacon API', () => {
     );
   });
 
+  it('preserves an existing query string on the endpoint for single-validator reads', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator(),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getBeaconValidator('https://beacon.example?apiKey=secret', {
+      validatorId: '1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators/1?apiKey=secret',
+    );
+  });
+
+  it('merges (not replaces) an existing query string on the endpoint for batch GET reads', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getBeaconValidators('https://beacon.example/api?apiKey=secret', {
+      validatorIds: ['1', '2'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/api/eth/v1/beacon/states/head/validators?apiKey=secret&id=1&id=2',
+    );
+  });
+
+  it('preserves an existing query string on the endpoint for batch POST reads', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validatorIds = Array.from({ length: 65 }, (_, index) => `${index}`);
+
+    await getBeaconValidators('https://beacon.example?apiKey=secret', {
+      validatorIds,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators?apiKey=secret',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: validatorIds }),
+      },
+    );
+  });
+
   it('deduplicates transport ids while preserving repeated aligned outputs', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(
@@ -262,6 +323,25 @@ describe('Beacon API', () => {
       VALID_PUBKEY_A,
       VALID_PUBKEY_B,
     ]);
+  });
+
+  it('matches a non-canonical (leading-zero) index request against the canonical response index', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [createRawValidator({ index: '12' })],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const states = await getBeaconValidatorStates('https://beacon.example', {
+      validatorIds: ['0012'],
+    });
+
+    expect(states[0]).not.toBeNull();
+    expect(states[0]?.validatorIndex).toBe(12);
   });
 
   it('rejects a blank validatorId in a batch request instead of sending it', async () => {
@@ -1227,6 +1307,62 @@ describe('Beacon API', () => {
     ).rejects.toThrow('expected a positive integer number of milliseconds');
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['pollIntervalMs', { pollIntervalMs: 2_147_483_648, timeoutMs: 5_000 }],
+    [
+      'requestTimeoutMs',
+      {
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+        requestTimeoutMs: 2_147_483_648,
+      },
+    ],
+  ] as const)(
+    // setTimeout silently clamps delays above 2147483647ms to ~1ms instead of
+    // throwing — a valid-looking multi-week value would busy-loop and hammer
+    // the endpoint instead of waiting, so any field that reaches a timer
+    // directly (pollIntervalMs, requestTimeoutMs) must be rejected up front.
+    'rejects a %s exceeding the setTimeout delay limit before making any request',
+    async (_fieldName, args) => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        waitForBeaconValidatorActivation('https://beacon.example', {
+          validatorId: '12',
+          ...args,
+        }),
+      ).rejects.toThrow('no greater than 2147483647');
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('allows a timeoutMs exceeding the setTimeout delay limit, since it is never passed to a timer directly', async () => {
+    vi.useFakeTimers();
+
+    // timeoutMs only feeds Date.now()-based deadline arithmetic; every actual
+    // timer delay derived from it is separately bounded by pollIntervalMs/
+    // requestTimeoutMs, so an activation wait longer than ~24.8 days is valid.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ status: 'active_ongoing' }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForBeaconValidatorActivation('https://beacon.example', {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 60 * 24 * 60 * 60 * 1_000, // 60 days
+      }),
+    ).resolves.toMatchObject({ status: 'active' });
   });
 
   it('rejects immediately when the endpoint is missing, without ever polling', async () => {

--- a/src/__tests__/beacon-api.test.ts
+++ b/src/__tests__/beacon-api.test.ts
@@ -1,0 +1,672 @@
+import {
+  type BeaconValidator,
+  getBeaconAPI,
+  getBeaconValidatorLifecycleStage,
+  getBeaconValidator,
+  getBeaconValidatorState,
+  getBeaconValidators,
+  getBeaconValidatorStates,
+  waitForBeaconValidatorActivation,
+} from '@/api/beacon';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const FAR_FUTURE_EPOCH = '18446744073709551615';
+
+const createRawValidator = (
+  overrides?: {
+    index?: BeaconValidator['index'] | null;
+    balance?: BeaconValidator['balance'];
+    status?: BeaconValidator['status'];
+    validator?: Partial<BeaconValidator['validator']>;
+  },
+): BeaconValidator => ({
+  index: typeof overrides?.index === 'undefined' ? '12' : (overrides.index as never),
+  balance: overrides?.balance ?? '32000000000',
+  status: overrides?.status ?? 'active_ongoing',
+  validator: {
+    pubkey: overrides?.validator?.pubkey ?? '0xabc',
+    withdrawal_credentials:
+      overrides?.validator?.withdrawal_credentials ?? '0xdef',
+    effective_balance:
+      overrides?.validator?.effective_balance ?? '32000000000',
+    slashed: overrides?.validator?.slashed ?? false,
+    activation_eligibility_epoch:
+      typeof overrides?.validator?.activation_eligibility_epoch === 'undefined'
+        ? '1'
+        : (overrides.validator.activation_eligibility_epoch as never),
+    activation_epoch:
+      typeof overrides?.validator?.activation_epoch === 'undefined'
+        ? '2'
+        : (overrides.validator.activation_epoch as never),
+    exit_epoch:
+      typeof overrides?.validator?.exit_epoch === 'undefined'
+        ? '3'
+        : (overrides.validator.exit_epoch as never),
+    withdrawable_epoch:
+      typeof overrides?.validator?.withdrawable_epoch === 'undefined'
+        ? '4'
+        : (overrides.validator.withdrawable_epoch as never),
+  },
+});
+
+describe('Beacon API', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('exports beacon helpers from the package entrypoint', async () => {
+    const entrypoint = await import('@/main');
+
+    expect(entrypoint.getBeaconValidatorState).toBeTypeOf('function');
+    expect(entrypoint.getBeaconValidatorStates).toBeTypeOf('function');
+    expect(entrypoint.getBeaconValidatorLifecycleStage).toBeTypeOf('function');
+    expect(entrypoint.waitForBeaconValidatorActivation).toBeTypeOf('function');
+  });
+
+  it('requests a single beacon validator by id', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator(),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const validator = await getBeaconValidator('https://beacon.example/api', {
+      validatorId: '0xabc/1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/api/eth/v1/beacon/states/head/validators/0xabc%2F1',
+    );
+    expect(validator?.index).toBe('12');
+  });
+
+  it('constructs bound beacon API methods', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const api = getBeaconAPI('https://beacon.example');
+    await api.getBeaconValidatorStates({ validatorIds: ['1', '2'] });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/eth/v1/beacon/states/head/validators?id=1&id=2',
+    );
+    expect(fetchMock.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('requests batch beacon validators with repeated id query parameters', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await getBeaconValidators('https://beacon.example/api', {
+      validatorIds: ['0xabc/1', '2'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://beacon.example/api/eth/v1/beacon/states/head/validators?id=0xabc%2F1&id=2',
+    );
+    expect(fetchMock.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('returns an empty validator batch without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example/api', { validatorIds: [] }),
+    ).resolves.toEqual([]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns empty validator states without calling fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', { validatorIds: [] }),
+    ).resolves.toEqual([]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when a beacon validator is not found', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: 'missing' }),
+    ).resolves.toBeNull();
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', {
+        validatorId: 'missing',
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('throws a clear error when beacon endpoint is missing', async () => {
+    await expect(
+      getBeaconAPI().getBeaconValidatorState({ validatorId: '1' }),
+    ).rejects.toThrow(
+      'Beacon endpoint is not configured. Provide extendedConfig.beacon.endpoint in SDK config.',
+    );
+  });
+
+  it('normalizes a single beacon validator state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator(),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).resolves.toEqual({
+      publicKey: '0xabc',
+      validatorIndex: 12,
+      status: 'active',
+      rawStatus: 'active_ongoing',
+      balanceGwei: 32000000000n,
+      effectiveBalanceGwei: 32000000000n,
+      slashed: false,
+      activationEligibilityEpoch: 1,
+      activationEpoch: 2,
+      exitEpoch: 3,
+      withdrawableEpoch: 4,
+    });
+  });
+
+  it('maps far-future exit epoch sentinel to null for a single validator state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({
+            validator: {
+              exit_epoch: FAR_FUTURE_EPOCH,
+            },
+          }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).resolves.toMatchObject({
+      activationEligibilityEpoch: 1,
+      activationEpoch: 2,
+      exitEpoch: null,
+      withdrawableEpoch: 4,
+    });
+  });
+
+  it('maps far-future withdrawable epoch sentinel to null for a single validator state', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({
+            validator: {
+              withdrawable_epoch: FAR_FUTURE_EPOCH,
+            },
+          }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).resolves.toMatchObject({
+      activationEligibilityEpoch: 1,
+      activationEpoch: 2,
+      exitEpoch: 3,
+      withdrawableEpoch: null,
+    });
+  });
+
+  it.each([
+    ['pending', 'pending'],
+    ['active', 'active'],
+    ['exited', 'exited'],
+    ['withdrawal_possible', 'withdrawal_ready'],
+    ['withdrawal_done', 'withdrawn'],
+  ] as const)(
+    'computes lifecycle stage %s from normalized beacon status %s',
+    (status, lifecycleStage) => {
+      expect(
+        getBeaconValidatorLifecycleStage({
+          status,
+        }),
+      ).toBe(lifecycleStage);
+    },
+  );
+
+  it.each([
+    ['pending_initialized', 'pending'],
+    ['pending_queued', 'pending'],
+    ['active_ongoing', 'active'],
+    ['active_exiting', 'active'],
+    ['active_slashed', 'active'],
+    ['exited_unslashed', 'exited'],
+    ['exited_slashed', 'exited'],
+    ['withdrawal_possible', 'withdrawal_possible'],
+    ['withdrawal_done', 'withdrawal_done'],
+  ] as const)('maps raw beacon status %s to normalized status %s', async (rawStatus, status) => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ status: rawStatus }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).resolves.toMatchObject({
+      status,
+      rawStatus,
+    });
+  });
+
+  it('rejects unknown validator statuses', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ status: 'mystery_status' as never }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: unsupported status mystery_status',
+    );
+  });
+
+  it('fails clearly when validator.slashed is malformed', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({
+            validator: {
+              slashed: 'false' as never,
+            },
+          }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '12' }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorState: validator.slashed must be a boolean',
+    );
+  });
+
+  it('converts optional numeric fields to null when unavailable', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({
+            index: null,
+            validator: {
+              activation_eligibility_epoch: null as never,
+              activation_epoch: null as never,
+              exit_epoch: null as never,
+              withdrawable_epoch: null as never,
+            },
+          }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorState('https://beacon.example', { validatorId: '0xabc' }),
+    ).resolves.toMatchObject({
+      validatorIndex: null,
+      activationEligibilityEpoch: null,
+      activationEpoch: null,
+      exitEpoch: null,
+      withdrawableEpoch: null,
+    });
+  });
+
+  it('returns normalized batch states in requested order and null for missing validators', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            createRawValidator({ index: '2', validator: { pubkey: '0xbbb' } }),
+            createRawValidator({ index: '1', validator: { pubkey: '0xaaa' } }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds: ['0xaaa', 'missing', '2'],
+      }),
+    ).resolves.toEqual([
+      {
+        publicKey: '0xaaa',
+        validatorIndex: 1,
+        status: 'active',
+        rawStatus: 'active_ongoing',
+        balanceGwei: 32000000000n,
+        effectiveBalanceGwei: 32000000000n,
+        slashed: false,
+        activationEligibilityEpoch: 1,
+        activationEpoch: 2,
+        exitEpoch: 3,
+        withdrawableEpoch: 4,
+      },
+      null,
+      {
+        publicKey: '0xbbb',
+        validatorIndex: 2,
+        status: 'active',
+        rawStatus: 'active_ongoing',
+        balanceGwei: 32000000000n,
+        effectiveBalanceGwei: 32000000000n,
+        slashed: false,
+        activationEligibilityEpoch: 1,
+        activationEpoch: 2,
+        exitEpoch: 3,
+        withdrawableEpoch: 4,
+      },
+    ]);
+  });
+
+  it('maps far-future epoch sentinels to null in batch normalization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            createRawValidator({
+              index: '1',
+              validator: {
+                pubkey: '0xaaa',
+                exit_epoch: FAR_FUTURE_EPOCH,
+              },
+            }),
+            createRawValidator({
+              index: '2',
+              validator: {
+                pubkey: '0xbbb',
+                withdrawable_epoch: FAR_FUTURE_EPOCH,
+              },
+            }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds: ['0xaaa', '0xbbb'],
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        publicKey: '0xaaa',
+        exitEpoch: null,
+        withdrawableEpoch: 4,
+      }),
+      expect.objectContaining({
+        publicKey: '0xbbb',
+        exitEpoch: 3,
+        withdrawableEpoch: null,
+      }),
+    ]);
+  });
+
+  it('returns null entries for a batch not-found response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 404 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', {
+        validatorIds: ['1', '2'],
+      }),
+    ).resolves.toEqual([null, null]);
+  });
+
+  it('throws a clear error when single validator response is missing data', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidator('https://beacon.example', { validatorId: '1' }),
+    ).rejects.toThrow('Beacon API returned an invalid response for getBeaconValidator');
+  });
+
+  it('throws a clear error when batch validator response data is invalid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: {
+            invalid: true,
+          },
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidators('https://beacon.example', { validatorIds: ['1'] }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidators',
+    );
+  });
+
+  it('throws a clear error when normalized batch validator response is malformed', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            createRawValidator({
+              validator: {
+                effective_balance: 32000000000 as never,
+              },
+            }),
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconValidatorStates('https://beacon.example', { validatorIds: ['1'] }),
+    ).rejects.toThrow(
+      'Beacon API returned an invalid response for getBeaconValidatorStates: validator.effective_balance must be a string',
+    );
+  });
+
+  it('waits for a validator to become active', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'pending_queued' }),
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits while pending validators contain far-future epoch sentinels', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({
+              status: 'pending_queued',
+              validator: {
+                activation_epoch: FAR_FUTURE_EPOCH,
+                exit_epoch: FAR_FUTURE_EPOCH,
+                withdrawable_epoch: FAR_FUTURE_EPOCH,
+              },
+            }),
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'active_ongoing' }),
+          }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      },
+    );
+    const activationExpectation = expect(activationPromise).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await activationExpectation;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('times out while waiting for validator activation', async () => {
+    vi.useFakeTimers();
+
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: createRawValidator({ status: 'pending_queued' }),
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const activationPromise = waitForBeaconValidatorActivation(
+      'https://beacon.example',
+      {
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 2_500,
+      },
+    );
+    const activationExpectation = expect(activationPromise).rejects.toThrow(
+      'Timed out waiting for beacon validator activation for 12 after 2500ms; last observed state: pending (pending_queued)',
+    );
+
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await activationExpectation;
+  });
+
+  it('fails clearly when activation is no longer possible', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: createRawValidator({ status: 'exited_unslashed' }),
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      getBeaconAPI('https://beacon.example').waitForBeaconValidatorActivation({
+        validatorId: '12',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(
+      'Beacon validator 12 reached terminal stage exited before activation',
+    );
+  });
+});

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -12,6 +12,17 @@ import {
 } from 'viem';
 import { describe, expect, it } from 'vitest';
 
+// Destructuring-to-discard (`const { x: _x, ...rest } = obj`) leaves an
+// unused binding; this avoids that while still preserving the right type.
+const omitKey = <T extends object, K extends keyof T>(
+  obj: T,
+  key: K,
+): Omit<T, K> => {
+  const clone: Partial<T> = { ...obj };
+  delete clone[key];
+  return clone as Omit<T, K>;
+};
+
 describe('SDK Initiation', async () => {
   const network = await initializeContract();
 
@@ -134,7 +145,7 @@ describe('SDK Initiation', async () => {
     const sdk = new SSVSDK({
       publicClient,
     });
-    const { beacon: _beacon, ...legacyConfig } = sdk.config;
+    const legacyConfig = omitKey(sdk.config, 'beacon');
 
     expect(isConfig(sdk.config)).toBe(true);
     expect(isConfig(legacyConfig)).toBe(false);
@@ -183,6 +194,35 @@ describe('SDK Initiation', async () => {
     ).toThrowError(expectedError);
   });
 
+  it.each(['beacon', 'rest', 'publicClient', 'api'] as const)(
+    'should reject an array in place of the %s field',
+    (fieldName) => {
+      const transport = http(hoodi.rpcUrls.default.http[0]);
+      const publicClient = createPublicClient({
+        chain: hoodi,
+        transport,
+      });
+
+      const sdk = new SSVSDK({
+        publicClient,
+      });
+
+      // typeof [] === 'object' in JS, so an array must be excluded
+      // explicitly wherever a config field is expected to be a plain object.
+      const malformedConfig = {
+        ...sdk.config,
+        [fieldName]: [],
+      };
+
+      expect(isConfig(malformedConfig)).toBe(false);
+      expect(
+        () => new SSVSDK(malformedConfig as unknown as typeof sdk.config),
+      ).toThrowError(
+        'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields',
+      );
+    },
+  );
+
   it('should reject an incomplete prebuilt config object missing beacon', () => {
     const transport = http(hoodi.rpcUrls.default.http[0]);
     const publicClient = createPublicClient({
@@ -193,11 +233,12 @@ describe('SDK Initiation', async () => {
     const originalSdk = new SSVSDK({
       publicClient,
     });
-    const { beacon: _beacon, ...incompleteConfig } = originalSdk.config;
+    const incompleteConfig = omitKey(originalSdk.config, 'beacon');
 
     expect(isConfig(incompleteConfig)).toBe(false);
     expect(
-      () => new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
+      () =>
+        new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
     ).toThrowError(
       'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields',
     );
@@ -216,7 +257,7 @@ describe('SDK Initiation', async () => {
         rest: { endpoint: 'https://custom-rest-endpoint.com/api' },
       },
     });
-    const { rest: _rest, ...incompleteConfig } = originalSdk.config;
+    const incompleteConfig = omitKey(originalSdk.config, 'rest');
 
     // Before the fix, hasIncompletePrebuiltConfigShape only ever inspected
     // beacon; a missing rest (or any other non-beacon field) short-circuited
@@ -225,7 +266,8 @@ describe('SDK Initiation', async () => {
     // erroring.
     expect(isConfig(incompleteConfig)).toBe(false);
     expect(
-      () => new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
+      () =>
+        new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
     ).toThrowError(
       'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields',
     );

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -70,6 +70,9 @@ describe('SDK Initiation', async () => {
       rest: {
         endpoint: 'https://custom-rest-endpoint.com/api',
       },
+      beacon: {
+        endpoint: 'https://custom-beacon-endpoint.com',
+      },
       contracts: customAddresses,
     } satisfies ConfigArgs['extendedConfig'];
 
@@ -84,7 +87,28 @@ describe('SDK Initiation', async () => {
     // Verify custom endpoints are used
     expect(sdk.config.subgraph.endpoint).toBe(extended.subgraph.endpoint);
     expect(sdk.config.rest.endpoint).toBe(extended.rest.endpoint);
+    expect(sdk.config.beacon.endpoint).toBe(extended.beacon.endpoint);
   });
+
+  it('should expose bound beacon helpers on sdk.api', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const sdk = new SSVSDK({
+      publicClient,
+    });
+
+    expect(sdk.api.getBeaconValidator).toBeTypeOf('function');
+    expect(sdk.api.getBeaconValidators).toBeTypeOf('function');
+    expect(sdk.api.getBeaconValidatorState).toBeTypeOf('function');
+    expect(sdk.api.getBeaconValidatorStates).toBeTypeOf('function');
+    expect(sdk.api.getBeaconValidatorLifecycleStage).toBeTypeOf('function');
+    expect(sdk.api.waitForBeaconValidatorActivation).toBeTypeOf('function');
+  });
+
   it('should initialize with paid subgraph', async () => {
     const transport = http(hoodi.rpcUrls.default.http[0]);
     const walletClient = createWalletClient({
@@ -134,6 +158,25 @@ describe('SDK Initiation', async () => {
           walletClient,
         });
       }).toThrowError('Public client must be provided');
+    });
+
+    it('should throw error when beacon endpoint is invalid', () => {
+      const transport = http(hoodi.rpcUrls.default.http[0]);
+      const publicClient = createPublicClient({
+        chain: hoodi,
+        transport,
+      });
+
+      expect(() => {
+        new SSVSDK({
+          publicClient,
+          extendedConfig: {
+            beacon: {
+              endpoint: 'not-a-url',
+            },
+          },
+        });
+      }).toThrowError('Invalid url');
     });
 
     it('should initialize without walletClient', () => {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -165,7 +165,7 @@ describe('SDK Initiation', async () => {
     ).toBe(false);
 
     const expectedError =
-      'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.';
+      'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields';
 
     expect(
       () =>
@@ -199,7 +199,35 @@ describe('SDK Initiation', async () => {
     expect(
       () => new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
     ).toThrowError(
-      'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.',
+      'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields',
+    );
+  });
+
+  it('should reject an incomplete prebuilt config object missing a non-beacon field', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const originalSdk = new SSVSDK({
+      publicClient,
+      extendedConfig: {
+        rest: { endpoint: 'https://custom-rest-endpoint.com/api' },
+      },
+    });
+    const { rest: _rest, ...incompleteConfig } = originalSdk.config;
+
+    // Before the fix, hasIncompletePrebuiltConfigShape only ever inspected
+    // beacon; a missing rest (or any other non-beacon field) short-circuited
+    // the guard to false and silently fell through to createConfig, which
+    // would have rebuilt rest.endpoint from the chain default instead of
+    // erroring.
+    expect(isConfig(incompleteConfig)).toBe(false);
+    expect(
+      () => new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
+    ).toThrowError(
+      'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields',
     );
   });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -163,6 +163,24 @@ describe('SDK Initiation', async () => {
         beacon: null,
       }),
     ).toBe(false);
+
+    const expectedError =
+      'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.';
+
+    expect(
+      () =>
+        new SSVSDK({
+          ...sdk.config,
+          beacon: undefined,
+        } as unknown as typeof sdk.config),
+    ).toThrowError(expectedError);
+    expect(
+      () =>
+        new SSVSDK({
+          ...sdk.config,
+          beacon: null,
+        } as unknown as typeof sdk.config),
+    ).toThrowError(expectedError);
   });
 
   it('should reject an incomplete prebuilt config object missing beacon', () => {

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -109,6 +109,48 @@ describe('SDK Initiation', async () => {
     expect(sdk.api.waitForBeaconValidatorActivation).toBeTypeOf('function');
   });
 
+  it('should accept a prebuilt config without beacon', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const originalSdk = new SSVSDK({
+      publicClient,
+    });
+    const { beacon: _beacon, ...legacyConfig } = originalSdk.config;
+
+    const sdk = new SSVSDK(legacyConfig as unknown as typeof originalSdk.config);
+
+    expect(sdk.config).toBe(legacyConfig);
+    expect('beacon' in sdk.config).toBe(false);
+  });
+
+  it('should accept a prebuilt config with beacon', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const existingConfig = new SSVSDK({
+      publicClient,
+      extendedConfig: {
+        beacon: {
+          endpoint: 'https://custom-beacon-endpoint.com',
+        },
+      },
+    }).config;
+
+    const sdk = new SSVSDK(existingConfig);
+
+    expect(sdk.config).toBe(existingConfig);
+    expect(sdk.config.beacon.endpoint).toBe(
+      'https://custom-beacon-endpoint.com',
+    );
+  });
+
   it('should initialize with paid subgraph', async () => {
     const transport = http(hoodi.rpcUrls.default.http[0]);
     const walletClient = createWalletClient({

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -1,3 +1,4 @@
+import { isConfig } from '@/config';
 import { chains, hoodi, paid_graph_endpoints } from '@/config/chains';
 import { SSVSDK } from '@/sdk';
 import type { ConfigArgs } from '@/utils';
@@ -109,7 +110,62 @@ describe('SDK Initiation', async () => {
     expect(sdk.api.waitForBeaconValidatorActivation).toBeTypeOf('function');
   });
 
-  it('should accept a prebuilt config without beacon', () => {
+  it('should initialize without beacon endpoint in normal config args', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const sdk = new SSVSDK({
+      publicClient,
+    });
+
+    expect(sdk.config.beacon.endpoint).toBeUndefined();
+  });
+
+  it('should only treat normalized configs as ConfigReturnType', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const sdk = new SSVSDK({
+      publicClient,
+    });
+    const { beacon: _beacon, ...legacyConfig } = sdk.config;
+
+    expect(isConfig(sdk.config)).toBe(true);
+    expect(isConfig(legacyConfig)).toBe(false);
+  });
+
+  it('should reject malformed configs with an invalid beacon shape', () => {
+    const transport = http(hoodi.rpcUrls.default.http[0]);
+    const publicClient = createPublicClient({
+      chain: hoodi,
+      transport,
+    });
+
+    const sdk = new SSVSDK({
+      publicClient,
+    });
+
+    expect(
+      isConfig({
+        ...sdk.config,
+        beacon: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      isConfig({
+        ...sdk.config,
+        beacon: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('should reject an incomplete prebuilt config object missing beacon', () => {
     const transport = http(hoodi.rpcUrls.default.http[0]);
     const publicClient = createPublicClient({
       chain: hoodi,
@@ -119,15 +175,17 @@ describe('SDK Initiation', async () => {
     const originalSdk = new SSVSDK({
       publicClient,
     });
-    const { beacon: _beacon, ...legacyConfig } = originalSdk.config;
+    const { beacon: _beacon, ...incompleteConfig } = originalSdk.config;
 
-    const sdk = new SSVSDK(legacyConfig as unknown as typeof originalSdk.config);
-
-    expect(sdk.config).toBe(legacyConfig);
-    expect('beacon' in sdk.config).toBe(false);
+    expect(isConfig(incompleteConfig)).toBe(false);
+    expect(
+      () => new SSVSDK(incompleteConfig as unknown as typeof originalSdk.config),
+    ).toThrowError(
+      'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.',
+    );
   });
 
-  it('should accept a prebuilt config with beacon', () => {
+  it('should accept a fully normalized prebuilt config with beacon', () => {
     const transport = http(hoodi.rpcUrls.default.http[0]);
     const publicClient = createPublicClient({
       chain: hoodi,

--- a/src/__tests__/mock-api.test.ts
+++ b/src/__tests__/mock-api.test.ts
@@ -152,9 +152,20 @@ describe('Mock API event completeness', () => {
     const { createMockApi } = await import('@/mock/api');
     const api = createMockApi(publicClient as never);
 
+    // Two different lengths: a hard-coded [null, null, null] would pass the
+    // 3-id case by coincidence but fail the 1-id and 5-id cases below.
+    await expect(
+      api.getBeaconValidatorStates({ validatorIds: ['1'] }),
+    ).resolves.toEqual([null]);
     await expect(
       api.getBeaconValidatorStates({ validatorIds: ['1', '2', '3'] }),
     ).resolves.toEqual([null, null, null]);
+    const fiveIds = ['1', '2', '3', '4', '5'];
+    const fiveResult = await api.getBeaconValidatorStates({
+      validatorIds: fiveIds,
+    });
+    expect(fiveResult).toHaveLength(fiveIds.length);
+    expect(fiveResult).toEqual(fiveIds.map(() => null));
   });
 
   it('includes the full beacon helper surface', async () => {

--- a/src/__tests__/mock-api.test.ts
+++ b/src/__tests__/mock-api.test.ts
@@ -147,4 +147,33 @@ describe('Mock API event completeness', () => {
       effectiveBalance: '32',
     });
   });
+
+  it('includes the full beacon helper surface', async () => {
+    const { createMockApi } = await import('@/mock/api');
+    const api = createMockApi(publicClient as never);
+
+    expect(api.checkOperatorDKGEnabled).toBeTypeOf('function');
+    expect(api.getDaoValues).toBeTypeOf('function');
+    expect(api.getBeaconValidator).toBeTypeOf('function');
+    expect(api.getBeaconValidators).toBeTypeOf('function');
+    expect(api.getBeaconValidatorState).toBeTypeOf('function');
+    expect(api.getBeaconValidatorStates).toBeTypeOf('function');
+    expect(api.getBeaconValidatorLifecycleStage).toBeTypeOf('function');
+    expect(api.waitForBeaconValidatorActivation).toBeTypeOf('function');
+
+    await expect(
+      api.waitForBeaconValidatorActivation({
+        validatorId: '1',
+        pollIntervalMs: 1_000,
+        timeoutMs: 5_000,
+      }),
+    ).resolves.toMatchObject({
+      status: 'active',
+      rawStatus: 'active_ongoing',
+    });
+
+    expect(
+      api.getBeaconValidatorLifecycleStage({ status: 'withdrawal_done' }),
+    ).toBe('withdrawn');
+  });
 });

--- a/src/__tests__/mock-api.test.ts
+++ b/src/__tests__/mock-api.test.ts
@@ -148,6 +148,15 @@ describe('Mock API event completeness', () => {
     });
   });
 
+  it('keeps getBeaconValidatorStates mock responses index-aligned with the request', async () => {
+    const { createMockApi } = await import('@/mock/api');
+    const api = createMockApi(publicClient as never);
+
+    await expect(
+      api.getBeaconValidatorStates({ validatorIds: ['1', '2', '3'] }),
+    ).resolves.toEqual([null, null, null]);
+  });
+
   it('includes the full beacon helper surface', async () => {
     const { createMockApi } = await import('@/mock/api');
     const api = createMockApi(publicClient as never);
@@ -161,16 +170,26 @@ describe('Mock API event completeness', () => {
     expect(api.getBeaconValidatorLifecycleStage).toBeTypeOf('function');
     expect(api.waitForBeaconValidatorActivation).toBeTypeOf('function');
 
-    await expect(
-      api.waitForBeaconValidatorActivation({
-        validatorId: '1',
-        pollIntervalMs: 1_000,
-        timeoutMs: 5_000,
-      }),
-    ).resolves.toMatchObject({
-      status: 'active',
-      rawStatus: 'active_ongoing',
+    // The mock resolves a fixed constant regardless of validatorId/pollIntervalMs/
+    // timeoutMs, so only its surface shape is asserted here — an exact-value
+    // match would pass even if the mock stopped honoring the real
+    // BeaconValidatorState contract, since it doesn't drive off getBeaconValidatorState.
+    const activatedState = await api.waitForBeaconValidatorActivation({
+      validatorId: '1',
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
     });
+
+    expect(activatedState).toEqual(
+      expect.objectContaining({
+        publicKey: expect.any(String),
+        status: expect.any(String),
+        rawStatus: expect.any(String),
+        slashed: expect.any(Boolean),
+      }),
+    );
+    expect(typeof activatedState.balanceGwei).toBe('bigint');
+    expect(typeof activatedState.effectiveBalanceGwei).toBe('bigint');
 
     expect(
       api.getBeaconValidatorLifecycleStage({ status: 'withdrawal_done' }),

--- a/src/__tests__/mock-api.test.ts
+++ b/src/__tests__/mock-api.test.ts
@@ -193,7 +193,7 @@ describe('Mock API event completeness', () => {
 
     expect(activatedState).toEqual(
       expect.objectContaining({
-        publicKey: expect.any(String),
+        publicKey: expect.stringMatching(/^0x[a-fA-F0-9]{96}$/),
         status: expect.any(String),
         rawStatus: expect.any(String),
         slashed: expect.any(Boolean),

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -756,6 +756,19 @@ export const waitForBeaconValidatorActivation = async (
   }
 
   const methodName = 'waitForBeaconValidatorActivation';
+
+  // A malformed endpoint throws a plain TypeError from buildBeaconURL, which
+  // isRetryableActivationError treats as retryable by default — left
+  // unchecked, that silently retries a failure that can never succeed for
+  // the entire timeoutMs instead of failing immediately.
+  try {
+    buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+  } catch {
+    throw new BeaconValidationError(
+      `Invalid beacon endpoint for ${methodName}: ${endpoint}`,
+    );
+  }
+
   // pollIntervalMs/requestTimeoutMs are passed to setTimeout-based timers and
   // so are bounded by MAX_TIMER_DELAY_MS; timeoutMs is only ever used for
   // Date.now()-based deadline arithmetic and can be arbitrarily large.

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -627,6 +627,31 @@ const toValidatorLookupKey = (validatorId: string) => {
 const isDotSegmentValidatorId = (validatorId: string): boolean =>
   /^\.+$/.test(validatorId);
 
+// A caller bypassing this SDK's own TS types via its compiled JS output can
+// pass a non-string validatorId, and even a well-typed string can contain
+// an unpaired UTF-16 surrogate that throws URIError from
+// encodeURIComponent — both are plain TypeError/URIError,
+// isRetryableActivationError's default, so left unchecked this retries a
+// permanent input error for the entire timeoutMs instead of failing fast.
+const assertEncodableValidatorId = (
+  validatorId: unknown,
+  methodName: string,
+): void => {
+  if (typeof validatorId !== 'string') {
+    throw new BeaconValidationError(
+      `${methodName} requires validatorId to be a string`,
+    );
+  }
+
+  try {
+    encodeURIComponent(validatorId);
+  } catch {
+    throw new BeaconValidationError(
+      `${methodName} requires a well-formed validatorId (found an unpaired surrogate)`,
+    );
+  }
+};
+
 // Both the GET and POST validator-batch endpoints require unique transport
 // ids; deduping here (rather than in getBeaconValidatorStates) keeps this a
 // transport-only concern — per-input-position output alignment already comes
@@ -694,6 +719,8 @@ export const getBeaconValidator = async (
     throw missingBeaconEndpointError();
   }
 
+  assertEncodableValidatorId(args.validatorId, 'getBeaconValidator');
+
   if (args.validatorId.trim().length === 0) {
     throw new BeaconValidationError(
       'getBeaconValidator requires a non-empty validatorId; an empty value would request the unfiltered validator list instead',
@@ -756,6 +783,10 @@ export const getBeaconValidators = async (
   if (args.validatorIds.length === 0) {
     return [];
   }
+
+  args.validatorIds.forEach((validatorId) =>
+    assertEncodableValidatorId(validatorId, 'getBeaconValidators'),
+  );
 
   if (
     args.validatorIds.some((validatorId) => validatorId.trim().length === 0)

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -60,16 +60,38 @@ export type WaitForBeaconValidatorActivationArgs = {
   pollIntervalMs: number;
   timeoutMs: number;
   failOnNotFound?: boolean;
+  // Caps each individual poll attempt so one stalled request can't consume
+  // the whole activation budget. Defaults to pollIntervalMs.
+  requestTimeoutMs?: number;
 };
 
 type BeaconResponse<T> = {
   data?: T;
 };
 
-// Beacon APIs use the uint64 max value as a sentinel for epochs that are not set yet.
+export class BeaconHttpError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'BeaconHttpError';
+    this.status = status;
+  }
+}
+
+export class BeaconValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BeaconValidationError';
+  }
+}
+
+// Beacon APIs use the uint64 max value as a sentinel for epochs that are not
+// set yet; the same bound doubles as the valid range ceiling for uint64 fields.
 const BEACON_FAR_FUTURE_EPOCH = 18446744073709551615n;
 const BEACON_VALIDATORS_PATH = '/eth/v1/beacon/states/head/validators';
 const BEACON_GET_VALIDATORS_MAX_URL_LENGTH = 7000;
+const BEACON_GET_VALIDATORS_MAX_COUNT = 64;
 
 const missingBeaconEndpointError = () =>
   new Error(
@@ -81,19 +103,36 @@ const assertBeaconData = <T>(
   methodName: string,
 ): T => {
   if (typeof payload !== 'object' || payload === null || !('data' in payload)) {
-    throw new Error(`Beacon API returned an invalid response for ${methodName}`);
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}`,
+    );
   }
 
   if (typeof payload.data === 'undefined') {
-    throw new Error(`Beacon API response is missing data for ${methodName}`);
+    throw new BeaconValidationError(
+      `Beacon API response is missing data for ${methodName}`,
+    );
   }
 
   return payload.data;
 };
 
+const parseBeaconJSON = async <T>(
+  response: Response,
+  methodName: string,
+): Promise<BeaconResponse<T>> => {
+  try {
+    return (await response.json()) as BeaconResponse<T>;
+  } catch {
+    throw new BeaconValidationError(
+      `Beacon API returned invalid JSON for ${methodName}`,
+    );
+  }
+};
+
 const assertString = (value: unknown, fieldName: string, methodName: string) => {
   if (typeof value !== 'string') {
-    throw new Error(
+    throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a string`,
     );
   }
@@ -107,7 +146,7 @@ const assertBoolean = (
   methodName: string,
 ) => {
   if (typeof value !== 'boolean') {
-    throw new Error(
+    throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a boolean`,
     );
   }
@@ -127,11 +166,72 @@ const mapOptionalString = (
   return assertString(value, fieldName, methodName);
 };
 
+// The Beacon API's uint64 primitive is a decimal string; BigInt() itself is
+// far more permissive (accepts '', whitespace, signs, and hex), so malformed
+// or adversarial responses must be rejected before reaching BigInt().
+const CANONICAL_UNSIGNED_INTEGER_PATTERN = /^(0|[1-9][0-9]*)$/;
+
+const parseCanonicalUint64String = (
+  rawValue: string,
+  fieldName: string,
+  methodName: string,
+): bigint => {
+  if (!CANONICAL_UNSIGNED_INTEGER_PATTERN.test(rawValue)) {
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a canonical non-negative integer string`,
+    );
+  }
+
+  const parsedValue = BigInt(rawValue);
+
+  if (parsedValue > BEACON_FAR_FUTURE_EPOCH) {
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds the uint64 range`,
+    );
+  }
+
+  return parsedValue;
+};
+
 const parseBigIntString = (
   value: unknown,
   fieldName: string,
   methodName: string,
-) => BigInt(assertString(value, fieldName, methodName));
+) =>
+  parseCanonicalUint64String(
+    assertString(value, fieldName, methodName),
+    fieldName,
+    methodName,
+  );
+
+// For fields where the far-future sentinel means "not set yet" (epochs only —
+// see parseOptionalSafeNumberString for fields like index that have no such
+// sentinel semantics).
+const parseOptionalSafeEpochString = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
+  const rawValue = mapOptionalString(value, fieldName, methodName);
+
+  if (rawValue === null) {
+    return null;
+  }
+
+  const parsedValue = parseCanonicalUint64String(rawValue, fieldName, methodName);
+
+  if (parsedValue === BEACON_FAR_FUTURE_EPOCH) {
+    return null;
+  }
+
+  if (parsedValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds MAX_SAFE_INTEGER`,
+    );
+  }
+
+  return Number(parsedValue);
+};
 
 const parseOptionalSafeNumberString = (
   value: unknown,
@@ -144,14 +244,10 @@ const parseOptionalSafeNumberString = (
     return null;
   }
 
-  const parsedValue = BigInt(rawValue);
-
-  if (parsedValue === BEACON_FAR_FUTURE_EPOCH) {
-    return null;
-  }
+  const parsedValue = parseCanonicalUint64String(rawValue, fieldName, methodName);
 
   if (parsedValue > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error(
+    throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds MAX_SAFE_INTEGER`,
     );
   }
@@ -180,7 +276,7 @@ const mapBeaconValidatorStatus = (
     case 'withdrawal_done':
       return normalizedStatus;
     default:
-      throw new Error(
+      throw new BeaconValidationError(
         `Beacon API returned an invalid response for ${methodName}: unsupported status ${normalizedStatus}`,
       );
   }
@@ -222,6 +318,24 @@ const createBudgetSignal = (budgetMs: number) => {
   };
 };
 
+// 408/429/5xx and network-level failures (including our own attempt-timeout
+// abort) are worth retrying; other 4xx statuses and response-validation
+// failures are permanent for a given input and would otherwise spin silently
+// until timeout, hiding the actionable error.
+const RETRYABLE_HTTP_STATUSES = new Set([408, 429]);
+
+const isRetryableActivationError = (error: unknown): boolean => {
+  if (error instanceof BeaconValidationError) {
+    return false;
+  }
+
+  if (error instanceof BeaconHttpError) {
+    return RETRYABLE_HTTP_STATUSES.has(error.status) || error.status >= 500;
+  }
+
+  return true;
+};
+
 const describeActivationWaitState = (state: BeaconValidatorState | null) => {
   if (state === null) {
     return 'not found';
@@ -252,11 +366,13 @@ const mapBeaconValidatorState = (
   methodName: string,
 ): BeaconValidatorState => {
   if (typeof validator !== 'object' || validator === null) {
-    throw new Error(`Beacon API returned an invalid response for ${methodName}`);
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}`,
+    );
   }
 
   if (typeof validator.validator !== 'object' || validator.validator === null) {
-    throw new Error(
+    throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: validator must be an object`,
     );
   }
@@ -277,22 +393,22 @@ const mapBeaconValidatorState = (
       methodName,
     ),
     slashed: assertBoolean(validator.validator.slashed, 'validator.slashed', methodName),
-    activationEligibilityEpoch: parseOptionalSafeNumberString(
+    activationEligibilityEpoch: parseOptionalSafeEpochString(
       validator.validator.activation_eligibility_epoch,
       'validator.activation_eligibility_epoch',
       methodName,
     ),
-    activationEpoch: parseOptionalSafeNumberString(
+    activationEpoch: parseOptionalSafeEpochString(
       validator.validator.activation_epoch,
       'validator.activation_epoch',
       methodName,
     ),
-    exitEpoch: parseOptionalSafeNumberString(
+    exitEpoch: parseOptionalSafeEpochString(
       validator.validator.exit_epoch,
       'validator.exit_epoch',
       methodName,
     ),
-    withdrawableEpoch: parseOptionalSafeNumberString(
+    withdrawableEpoch: parseOptionalSafeEpochString(
       validator.validator.withdrawable_epoch,
       'validator.withdrawable_epoch',
       methodName,
@@ -301,6 +417,14 @@ const mapBeaconValidatorState = (
 };
 
 const toValidatorLookupKey = (validatorId: string) => validatorId.toLowerCase();
+
+// Both the GET and POST validator-batch endpoints require unique transport
+// ids; deduping here (rather than in getBeaconValidatorStates) keeps this a
+// transport-only concern — per-input-position output alignment already comes
+// from the lookup-map pass in getBeaconValidatorStates below, independent of
+// how many times an id was repeated on the wire.
+const dedupeValidatorIds = (validatorIds: string[]): string[] =>
+  Array.from(new Set(validatorIds));
 
 const getBeaconValidatorsURL = (
   endpoint: string,
@@ -323,8 +447,15 @@ const getBeaconValidatorsRequest = (
 ): { url: string; init?: RequestInit } => {
   const url = getBeaconValidatorsURL(endpoint, validatorIds);
 
-  // Long validator ids can exceed provider or proxy URL limits before batch size does.
-  if (url.length <= BEACON_GET_VALIDATORS_MAX_URL_LENGTH) {
+  // The GET endpoint's id[] query param is capped at 64 unique items by the
+  // spec (maxItems: 64, and a documented 414 above that); long validator ids
+  // can also exceed provider/proxy URL limits before that count is reached.
+  // The POST body has no such count cap and exists precisely to support
+  // larger batches.
+  if (
+    validatorIds.length <= BEACON_GET_VALIDATORS_MAX_COUNT &&
+    url.length <= BEACON_GET_VALIDATORS_MAX_URL_LENGTH
+  ) {
     return {
       url,
     };
@@ -351,7 +482,7 @@ export const getBeaconValidator = async (
   }
 
   if (args.validatorId.trim().length === 0) {
-    throw new Error(
+    throw new BeaconValidationError(
       'getBeaconValidator requires a non-empty validatorId; an empty value would request the unfiltered validator list instead',
     );
   }
@@ -369,13 +500,14 @@ export const getBeaconValidator = async (
   }
 
   if (!response.ok) {
-    throw new Error(
+    throw new BeaconHttpError(
+      response.status,
       `Beacon API request failed for getBeaconValidator with status ${response.status}`,
     );
   }
 
   return assertBeaconData<BeaconValidator>(
-    (await response.json()) as BeaconResponse<BeaconValidator>,
+    await parseBeaconJSON<BeaconValidator>(response, 'getBeaconValidator'),
     'getBeaconValidator',
   );
 };
@@ -392,7 +524,14 @@ export const getBeaconValidators = async (
     return [];
   }
 
-  const request = getBeaconValidatorsRequest(endpoint, args.validatorIds);
+  if (args.validatorIds.some((validatorId) => validatorId.trim().length === 0)) {
+    throw new BeaconValidationError(
+      'getBeaconValidators requires every validatorId to be non-empty',
+    );
+  }
+
+  const dedupedValidatorIds = dedupeValidatorIds(args.validatorIds);
+  const request = getBeaconValidatorsRequest(endpoint, dedupedValidatorIds);
   const response = request.init
     ? await fetch(request.url, request.init)
     : await fetch(request.url);
@@ -402,18 +541,19 @@ export const getBeaconValidators = async (
   // here means the state/route itself is wrong (e.g. misconfigured
   // endpoint), so it must not be swallowed into an empty result.
   if (!response.ok) {
-    throw new Error(
+    throw new BeaconHttpError(
+      response.status,
       `Beacon API request failed for getBeaconValidators with status ${response.status}`,
     );
   }
 
   const data = assertBeaconData<BeaconValidator[]>(
-    (await response.json()) as BeaconResponse<BeaconValidator[]>,
+    await parseBeaconJSON<BeaconValidator[]>(response, 'getBeaconValidators'),
     'getBeaconValidators',
   );
 
   if (!Array.isArray(data)) {
-    throw new Error(
+    throw new BeaconValidationError(
       'Beacon API returned an invalid response for getBeaconValidators',
     );
   }
@@ -480,10 +620,17 @@ export const waitForBeaconValidatorActivation = async (
     methodName,
   );
   const timeoutMs = assertPositiveInteger(args.timeoutMs, 'timeoutMs', methodName);
+  const requestTimeoutMs = assertPositiveInteger(
+    args.requestTimeoutMs ?? pollIntervalMs,
+    'requestTimeoutMs',
+    methodName,
+  );
   const deadline = Date.now() + timeoutMs;
   let lastObservedState: BeaconValidatorState | null = null;
+  let lastRetryableError: unknown = null;
 
   const timeoutError = () =>
+    lastRetryableError ??
     new Error(
       `Timed out waiting for beacon validator activation for ${args.validatorId} after ${timeoutMs}ms; last observed state: ${describeActivationWaitState(lastObservedState)}`,
     );
@@ -495,11 +642,11 @@ export const waitForBeaconValidatorActivation = async (
       throw timeoutError();
     }
 
-    // Bound each attempt by the remaining budget so a stalled request can't
-    // block the wait past timeoutMs, and retry transient fetch failures
-    // (network errors, 429/5xx, this abort) instead of rejecting the whole
-    // wait on a single blip.
-    const { signal, dispose } = createBudgetSignal(remainingBudgetMs);
+    // Bound each attempt by the smaller of the remaining deadline and
+    // requestTimeoutMs — not the full remaining budget — so a single stalled
+    // request can't consume the entire wait with zero retries in between.
+    const attemptBudgetMs = Math.min(remainingBudgetMs, requestTimeoutMs);
+    const { signal, dispose } = createBudgetSignal(attemptBudgetMs);
     let state: BeaconValidatorState | null;
 
     try {
@@ -508,6 +655,12 @@ export const waitForBeaconValidatorActivation = async (
         signal,
       });
     } catch (error) {
+      if (!isRetryableActivationError(error)) {
+        throw error;
+      }
+
+      lastRetryableError = error;
+
       const remainingMs = deadline - Date.now();
 
       if (remainingMs <= 0) {
@@ -520,6 +673,7 @@ export const waitForBeaconValidatorActivation = async (
       dispose();
     }
 
+    lastRetryableError = null;
     lastObservedState = state;
 
     if (state === null && args.failOnNotFound) {

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -45,7 +45,7 @@ export type BeaconValidatorState = {
   publicKey: string;
   validatorIndex: number | null;
   status: BeaconValidatorStatus;
-  rawStatus: string;
+  rawStatus: RawBeaconValidatorStatus;
   balanceGwei: bigint;
   effectiveBalanceGwei: bigint;
   slashed: boolean;
@@ -82,6 +82,9 @@ export class BeaconHttpError extends Error {
   }
 }
 
+// Covers both "the remote response was invalid" and "the caller's own input
+// can never succeed" (e.g. a blank validatorId, a non-positive timeoutMs) —
+// both are permanent, non-retryable conditions for isRetryableActivationError.
 export class BeaconValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -92,6 +95,7 @@ export class BeaconValidationError extends Error {
 // Beacon APIs use the uint64 max value as a sentinel for epochs that are not
 // set yet; the same bound doubles as the valid range ceiling for uint64 fields.
 const BEACON_FAR_FUTURE_EPOCH = 18446744073709551615n;
+const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
 const BEACON_VALIDATORS_PATH = '/eth/v1/beacon/states/head/validators';
 const BEACON_GET_VALIDATORS_MAX_URL_LENGTH = 7000;
 const BEACON_GET_VALIDATORS_MAX_COUNT = 64;
@@ -184,8 +188,10 @@ const mapOptionalString = (
 
 // The Beacon API's uint64 primitive is a decimal string; BigInt() itself is
 // far more permissive (accepts '', whitespace, signs, and hex), so malformed
-// or adversarial responses must be rejected before reaching BigInt().
-const CANONICAL_UNSIGNED_INTEGER_PATTERN = /^(0|[1-9][0-9]*)$/;
+// or adversarial responses must be rejected before reaching BigInt(). The
+// {0,19} bound caps total digit count at 20 (uint64's max), so a pathological
+// digit string is rejected by the regex itself before ever reaching BigInt().
+const CANONICAL_UNSIGNED_INTEGER_PATTERN = /^(0|[1-9][0-9]{0,19})$/;
 
 const parseCanonicalUint64String = (
   rawValue: string,
@@ -240,7 +246,7 @@ const parseOptionalSafeEpochString = (
     return null;
   }
 
-  if (parsedValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+  if (parsedValue > MAX_SAFE_INTEGER_BIGINT) {
     throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds MAX_SAFE_INTEGER`,
     );
@@ -262,7 +268,7 @@ const parseOptionalSafeNumberString = (
 
   const parsedValue = parseCanonicalUint64String(rawValue, fieldName, methodName);
 
-  if (parsedValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+  if (parsedValue > MAX_SAFE_INTEGER_BIGINT) {
     throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds MAX_SAFE_INTEGER`,
     );
@@ -304,7 +310,7 @@ const assertPositiveInteger = (
   methodName: string,
 ) => {
   if (!Number.isInteger(value) || value <= 0) {
-    throw new Error(
+    throw new BeaconValidationError(
       `Invalid ${fieldName} for ${methodName}: expected a positive integer number of milliseconds`,
     );
   }
@@ -401,7 +407,13 @@ const mapBeaconValidatorState = (
       methodName,
     ),
     status: mapBeaconValidatorStatus(validator.status, methodName),
-    rawStatus: assertString(validator.status, 'status', methodName),
+    // Safe: mapBeaconValidatorStatus above already threw unless
+    // validator.status is one of RawBeaconValidatorStatus's exact values.
+    rawStatus: assertString(
+      validator.status,
+      'status',
+      methodName,
+    ) as RawBeaconValidatorStatus,
     balanceGwei: parseBigIntString(validator.balance, 'balance', methodName),
     effectiveBalanceGwei: parseBigIntString(
       validator.validator.effective_balance,
@@ -442,24 +454,17 @@ const toValidatorLookupKey = (validatorId: string) => validatorId.toLowerCase();
 const dedupeValidatorIds = (validatorIds: string[]): string[] =>
   Array.from(new Set(validatorIds));
 
-const getBeaconValidatorsURL = (
-  endpoint: string,
-  validatorIds: string[],
-) => {
-  const url = join(endpoint, BEACON_VALIDATORS_PATH);
-
-  if (validatorIds.length === 0) {
-    return url;
-  }
-
-  return `${url}?${validatorIds
+// Only ever called with a non-empty, deduped id list (getBeaconValidators
+// early-returns before this point for an empty batch), so no empty-array case.
+const getBeaconValidatorsURL = (endpoint: string, validatorIds: string[]) =>
+  `${join(endpoint, BEACON_VALIDATORS_PATH)}?${validatorIds
     .map((validatorId) => `id=${encodeURIComponent(validatorId)}`)
     .join('&')}`;
-};
 
 const getBeaconValidatorsRequest = (
   endpoint: string,
   validatorIds: string[],
+  signal?: AbortSignal,
 ): { url: string; init?: RequestInit } => {
   const url = getBeaconValidatorsURL(endpoint, validatorIds);
 
@@ -474,6 +479,7 @@ const getBeaconValidatorsRequest = (
   ) {
     return {
       url,
+      init: signal ? { signal } : undefined,
     };
   }
 
@@ -485,10 +491,14 @@ const getBeaconValidatorsRequest = (
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ ids: validatorIds }),
+      signal,
     },
   };
 };
 
+// Validates the response envelope only (has a `data` key, right JSON shape).
+// Field-level shape (e.g. validator.pubkey, balance) is NOT checked here —
+// use getBeaconValidatorState for a fully-validated, normalized read.
 export const getBeaconValidator = async (
   endpoint: string | undefined,
   args: { validatorId: string; signal?: AbortSignal },
@@ -528,9 +538,12 @@ export const getBeaconValidator = async (
   );
 };
 
+// Validates the response envelope and that `data` is an array — not each
+// element's field-level shape. Use getBeaconValidatorStates for a fully
+// validated, normalized, input-aligned read.
 export const getBeaconValidators = async (
   endpoint: string | undefined,
-  args: { validatorIds: string[] },
+  args: { validatorIds: string[]; signal?: AbortSignal },
 ): Promise<BeaconValidator[]> => {
   if (!endpoint) {
     throw missingBeaconEndpointError();
@@ -547,7 +560,11 @@ export const getBeaconValidators = async (
   }
 
   const dedupedValidatorIds = dedupeValidatorIds(args.validatorIds);
-  const request = getBeaconValidatorsRequest(endpoint, dedupedValidatorIds);
+  const request = getBeaconValidatorsRequest(
+    endpoint,
+    dedupedValidatorIds,
+    args.signal,
+  );
   const response = request.init
     ? await fetch(request.url, request.init)
     : await fetch(request.url);
@@ -592,7 +609,7 @@ export const getBeaconValidatorState = async (
 
 export const getBeaconValidatorStates = async (
   endpoint: string | undefined,
-  args: { validatorIds: string[] },
+  args: { validatorIds: string[]; signal?: AbortSignal },
 ): Promise<Array<BeaconValidatorState | null>> => {
   const validators = await getBeaconValidators(endpoint, args);
   const validatorsById = new Map<string, BeaconValidatorState>();

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -1,0 +1,480 @@
+import join from '@/utils/url-join';
+
+export type BeaconValidator = {
+  index: string;
+  balance: string;
+  status: string;
+  validator: {
+    pubkey: string;
+    withdrawal_credentials: string;
+    effective_balance: string;
+    slashed: boolean;
+    activation_eligibility_epoch: string;
+    activation_epoch: string;
+    exit_epoch: string;
+    withdrawable_epoch: string;
+  };
+};
+
+export type BeaconValidatorStatus =
+  | 'pending'
+  | 'active'
+  | 'exited'
+  | 'withdrawal_possible'
+  | 'withdrawal_done';
+
+export type BeaconValidatorLifecycleStage =
+  | 'pending'
+  | 'active'
+  | 'exited'
+  | 'withdrawal_ready'
+  | 'withdrawn';
+
+export type RawBeaconValidatorStatus =
+  | 'pending_initialized'
+  | 'pending_queued'
+  | 'active_ongoing'
+  | 'active_exiting'
+  | 'active_slashed'
+  | 'exited_unslashed'
+  | 'exited_slashed'
+  | 'withdrawal_possible'
+  | 'withdrawal_done';
+
+export type BeaconValidatorState = {
+  publicKey: string;
+  validatorIndex: number | null;
+  status: BeaconValidatorStatus;
+  rawStatus: string;
+  balanceGwei: bigint;
+  effectiveBalanceGwei: bigint;
+  slashed: boolean;
+  activationEligibilityEpoch: number | null;
+  activationEpoch: number | null;
+  exitEpoch: number | null;
+  withdrawableEpoch: number | null;
+};
+
+export type WaitForBeaconValidatorActivationArgs = {
+  validatorId: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+};
+
+type BeaconResponse<T> = {
+  data?: T;
+};
+
+// Beacon APIs use the uint64 max value as a sentinel for epochs that are not set yet.
+const BEACON_FAR_FUTURE_EPOCH = 18446744073709551615n;
+const BEACON_VALIDATORS_PATH = '/eth/v1/beacon/states/head/validators';
+
+const missingBeaconEndpointError = () =>
+  new Error(
+    'Beacon endpoint is not configured. Provide extendedConfig.beacon.endpoint in SDK config.',
+  );
+
+const assertBeaconData = <T>(
+  payload: BeaconResponse<T>,
+  methodName: string,
+): T => {
+  if (typeof payload !== 'object' || payload === null || !('data' in payload)) {
+    throw new Error(`Beacon API returned an invalid response for ${methodName}`);
+  }
+
+  if (typeof payload.data === 'undefined') {
+    throw new Error(`Beacon API response is missing data for ${methodName}`);
+  }
+
+  return payload.data;
+};
+
+const assertString = (value: unknown, fieldName: string, methodName: string) => {
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a string`,
+    );
+  }
+
+  return value;
+};
+
+const assertBoolean = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
+  if (typeof value !== 'boolean') {
+    throw new Error(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a boolean`,
+    );
+  }
+
+  return value;
+};
+
+const mapOptionalString = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
+  if (typeof value === 'undefined' || value === null) {
+    return null;
+  }
+
+  return assertString(value, fieldName, methodName);
+};
+
+const parseBigIntString = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => BigInt(assertString(value, fieldName, methodName));
+
+const parseOptionalSafeNumberString = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
+  const rawValue = mapOptionalString(value, fieldName, methodName);
+
+  if (rawValue === null) {
+    return null;
+  }
+
+  const parsedValue = BigInt(rawValue);
+
+  if (parsedValue === BEACON_FAR_FUTURE_EPOCH) {
+    return null;
+  }
+
+  if (parsedValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} exceeds MAX_SAFE_INTEGER`,
+    );
+  }
+
+  return Number(parsedValue);
+};
+
+const mapBeaconValidatorStatus = (
+  status: unknown,
+  methodName: string,
+): BeaconValidatorStatus => {
+  const normalizedStatus = assertString(status, 'status', methodName);
+
+  switch (normalizedStatus) {
+    case 'pending_initialized':
+    case 'pending_queued':
+      return 'pending';
+    case 'active_ongoing':
+    case 'active_exiting':
+    case 'active_slashed':
+      return 'active';
+    case 'exited_unslashed':
+    case 'exited_slashed':
+      return 'exited';
+    case 'withdrawal_possible':
+    case 'withdrawal_done':
+      return normalizedStatus;
+    default:
+      throw new Error(
+        `Beacon API returned an invalid response for ${methodName}: unsupported status ${normalizedStatus}`,
+      );
+  }
+};
+
+const assertPositiveInteger = (
+  value: number,
+  fieldName: string,
+  methodName: string,
+) => {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `Invalid ${fieldName} for ${methodName}: expected a positive integer number of milliseconds`,
+    );
+  }
+
+  return value;
+};
+
+const sleep = (delayMs: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+const describeActivationWaitState = (state: BeaconValidatorState | null) => {
+  if (state === null) {
+    return 'not found';
+  }
+
+  return `${getBeaconValidatorLifecycleStage(state)} (${state.rawStatus})`;
+};
+
+export const getBeaconValidatorLifecycleStage = (
+  state: Pick<BeaconValidatorState, 'status'>,
+): BeaconValidatorLifecycleStage => {
+  switch (state.status) {
+    case 'pending':
+      return 'pending';
+    case 'active':
+      return 'active';
+    case 'exited':
+      return 'exited';
+    case 'withdrawal_possible':
+      return 'withdrawal_ready';
+    case 'withdrawal_done':
+      return 'withdrawn';
+  }
+};
+
+const mapBeaconValidatorState = (
+  validator: BeaconValidator,
+  methodName: string,
+): BeaconValidatorState => {
+  if (typeof validator !== 'object' || validator === null) {
+    throw new Error(`Beacon API returned an invalid response for ${methodName}`);
+  }
+
+  if (typeof validator.validator !== 'object' || validator.validator === null) {
+    throw new Error(
+      `Beacon API returned an invalid response for ${methodName}: validator must be an object`,
+    );
+  }
+
+  return {
+    publicKey: assertString(validator.validator.pubkey, 'validator.pubkey', methodName),
+    validatorIndex: parseOptionalSafeNumberString(
+      validator.index,
+      'index',
+      methodName,
+    ),
+    status: mapBeaconValidatorStatus(validator.status, methodName),
+    rawStatus: assertString(validator.status, 'status', methodName),
+    balanceGwei: parseBigIntString(validator.balance, 'balance', methodName),
+    effectiveBalanceGwei: parseBigIntString(
+      validator.validator.effective_balance,
+      'validator.effective_balance',
+      methodName,
+    ),
+    slashed: assertBoolean(validator.validator.slashed, 'validator.slashed', methodName),
+    activationEligibilityEpoch: parseOptionalSafeNumberString(
+      validator.validator.activation_eligibility_epoch,
+      'validator.activation_eligibility_epoch',
+      methodName,
+    ),
+    activationEpoch: parseOptionalSafeNumberString(
+      validator.validator.activation_epoch,
+      'validator.activation_epoch',
+      methodName,
+    ),
+    exitEpoch: parseOptionalSafeNumberString(
+      validator.validator.exit_epoch,
+      'validator.exit_epoch',
+      methodName,
+    ),
+    withdrawableEpoch: parseOptionalSafeNumberString(
+      validator.validator.withdrawable_epoch,
+      'validator.withdrawable_epoch',
+      methodName,
+    ),
+  };
+};
+
+const toValidatorLookupKey = (validatorId: string) => validatorId.toLowerCase();
+
+const getBeaconValidatorsURL = (
+  endpoint: string,
+  validatorIds: string[],
+) => {
+  const url = join(endpoint, BEACON_VALIDATORS_PATH);
+
+  if (validatorIds.length === 0) {
+    return url;
+  }
+
+  return `${url}?${validatorIds
+    .map((validatorId) => `id=${encodeURIComponent(validatorId)}`)
+    .join('&')}`;
+};
+
+export const getBeaconValidator = async (
+  endpoint: string | undefined,
+  args: { validatorId: string },
+): Promise<BeaconValidator | null> => {
+  if (!endpoint) {
+    throw missingBeaconEndpointError();
+  }
+
+  const response = await fetch(
+    join(
+      endpoint,
+      `/eth/v1/beacon/states/head/validators/${encodeURIComponent(args.validatorId)}`,
+    ),
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Beacon API request failed for getBeaconValidator with status ${response.status}`,
+    );
+  }
+
+  return assertBeaconData<BeaconValidator>(
+    (await response.json()) as BeaconResponse<BeaconValidator>,
+    'getBeaconValidator',
+  );
+};
+
+export const getBeaconValidators = async (
+  endpoint: string | undefined,
+  args: { validatorIds: string[] },
+): Promise<BeaconValidator[]> => {
+  if (!endpoint) {
+    throw missingBeaconEndpointError();
+  }
+
+  if (args.validatorIds.length === 0) {
+    return [];
+  }
+
+  const response = await fetch(
+    getBeaconValidatorsURL(endpoint, args.validatorIds),
+  );
+
+  if (response.status === 404) {
+    return [];
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Beacon API request failed for getBeaconValidators with status ${response.status}`,
+    );
+  }
+
+  const data = assertBeaconData<BeaconValidator[]>(
+    (await response.json()) as BeaconResponse<BeaconValidator[]>,
+    'getBeaconValidators',
+  );
+
+  if (!Array.isArray(data)) {
+    throw new Error(
+      'Beacon API returned an invalid response for getBeaconValidators',
+    );
+  }
+
+  return data;
+};
+
+export const getBeaconValidatorState = async (
+  endpoint: string | undefined,
+  args: { validatorId: string },
+): Promise<BeaconValidatorState | null> => {
+  const validator = await getBeaconValidator(endpoint, args);
+
+  if (validator === null) {
+    return null;
+  }
+
+  return mapBeaconValidatorState(validator, 'getBeaconValidatorState');
+};
+
+export const getBeaconValidatorStates = async (
+  endpoint: string | undefined,
+  args: { validatorIds: string[] },
+): Promise<Array<BeaconValidatorState | null>> => {
+  if (args.validatorIds.length === 0) {
+    return [];
+  }
+
+  const validators = await getBeaconValidators(endpoint, args);
+  const validatorsById = new Map<string, BeaconValidatorState>();
+
+  for (const validator of validators) {
+    const normalizedValidator = mapBeaconValidatorState(
+      validator,
+      'getBeaconValidatorStates',
+    );
+
+    validatorsById.set(
+      toValidatorLookupKey(normalizedValidator.publicKey),
+      normalizedValidator,
+    );
+
+    if (normalizedValidator.validatorIndex !== null) {
+      validatorsById.set(
+        toValidatorLookupKey(String(normalizedValidator.validatorIndex)),
+        normalizedValidator,
+      );
+    }
+  }
+
+  return args.validatorIds.map(
+    (validatorId) => validatorsById.get(toValidatorLookupKey(validatorId)) ?? null,
+  );
+};
+
+export const waitForBeaconValidatorActivation = async (
+  endpoint: string | undefined,
+  args: WaitForBeaconValidatorActivationArgs,
+): Promise<BeaconValidatorState> => {
+  if (!endpoint) {
+    throw missingBeaconEndpointError();
+  }
+
+  const methodName = 'waitForBeaconValidatorActivation';
+  const pollIntervalMs = assertPositiveInteger(
+    args.pollIntervalMs,
+    'pollIntervalMs',
+    methodName,
+  );
+  const timeoutMs = assertPositiveInteger(args.timeoutMs, 'timeoutMs', methodName);
+  const deadline = Date.now() + timeoutMs;
+  let lastObservedState: BeaconValidatorState | null = null;
+
+  while (true) {
+    const state = await getBeaconValidatorState(endpoint, {
+      validatorId: args.validatorId,
+    });
+    lastObservedState = state;
+
+    if (state !== null) {
+      const lifecycleStage = getBeaconValidatorLifecycleStage(state);
+
+      if (lifecycleStage === 'active') {
+        return state;
+      }
+
+      if (lifecycleStage !== 'pending') {
+        throw new Error(
+          `Beacon validator ${args.validatorId} reached terminal stage ${lifecycleStage} before activation`,
+        );
+      }
+    }
+
+    const remainingMs = deadline - Date.now();
+
+    if (remainingMs <= 0) {
+      throw new Error(
+        `Timed out waiting for beacon validator activation for ${args.validatorId} after ${timeoutMs}ms; last observed state: ${describeActivationWaitState(lastObservedState)}`,
+      );
+    }
+
+    await sleep(Math.min(pollIntervalMs, remainingMs));
+  }
+};
+
+export const getBeaconAPI = (endpoint?: string) => ({
+  getBeaconValidator: getBeaconValidator.bind(null, endpoint),
+  getBeaconValidators: getBeaconValidators.bind(null, endpoint),
+  getBeaconValidatorState: getBeaconValidatorState.bind(null, endpoint),
+  getBeaconValidatorStates: getBeaconValidatorStates.bind(null, endpoint),
+  getBeaconValidatorLifecycleStage,
+  waitForBeaconValidatorActivation: waitForBeaconValidatorActivation.bind(
+    null,
+    endpoint,
+  ),
+});

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -150,7 +150,11 @@ const parseBeaconJSON = async <T>(
   }
 };
 
-const assertString = (value: unknown, fieldName: string, methodName: string) => {
+const assertString = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
   if (typeof value !== 'string') {
     throw new BeaconValidationError(
       `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a string`,
@@ -158,6 +162,26 @@ const assertString = (value: unknown, fieldName: string, methodName: string) => 
   }
 
   return value;
+};
+
+// Beacon validator pubkeys are BLS public keys: 48 bytes, 0x-prefixed hex,
+// case insensitive. https://github.com/ethereum/beacon-APIs types/primitive.yaml#Pubkey
+const BEACON_PUBKEY_PATTERN = /^0x[a-fA-F0-9]{96}$/;
+
+const assertBeaconPubkey = (
+  value: unknown,
+  fieldName: string,
+  methodName: string,
+) => {
+  const rawValue = assertString(value, fieldName, methodName);
+
+  if (!BEACON_PUBKEY_PATTERN.test(rawValue)) {
+    throw new BeaconValidationError(
+      `Beacon API returned an invalid response for ${methodName}: ${fieldName} must be a 0x-prefixed 48-byte hex string`,
+    );
+  }
+
+  return rawValue;
 };
 
 const assertBoolean = (
@@ -240,7 +264,11 @@ const parseOptionalSafeEpochString = (
     return null;
   }
 
-  const parsedValue = parseCanonicalUint64String(rawValue, fieldName, methodName);
+  const parsedValue = parseCanonicalUint64String(
+    rawValue,
+    fieldName,
+    methodName,
+  );
 
   if (parsedValue === BEACON_FAR_FUTURE_EPOCH) {
     return null;
@@ -266,7 +294,11 @@ const parseOptionalSafeNumberString = (
     return null;
   }
 
-  const parsedValue = parseCanonicalUint64String(rawValue, fieldName, methodName);
+  const parsedValue = parseCanonicalUint64String(
+    rawValue,
+    fieldName,
+    methodName,
+  );
 
   if (parsedValue > MAX_SAFE_INTEGER_BIGINT) {
     throw new BeaconValidationError(
@@ -331,7 +363,9 @@ const sleep = (delayMs: number) =>
 const createBudgetSignal = (budgetMs: number) => {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
-    controller.abort(new Error(`Beacon request exceeded its ${budgetMs}ms time budget`));
+    controller.abort(
+      new Error(`Beacon request exceeded its ${budgetMs}ms time budget`),
+    );
   }, budgetMs);
 
   return {
@@ -400,7 +434,11 @@ const mapBeaconValidatorState = (
   }
 
   return {
-    publicKey: assertString(validator.validator.pubkey, 'validator.pubkey', methodName),
+    publicKey: assertBeaconPubkey(
+      validator.validator.pubkey,
+      'validator.pubkey',
+      methodName,
+    ),
     validatorIndex: parseOptionalSafeNumberString(
       validator.index,
       'index',
@@ -420,7 +458,11 @@ const mapBeaconValidatorState = (
       'validator.effective_balance',
       methodName,
     ),
-    slashed: assertBoolean(validator.validator.slashed, 'validator.slashed', methodName),
+    slashed: assertBoolean(
+      validator.validator.slashed,
+      'validator.slashed',
+      methodName,
+    ),
     activationEligibilityEpoch: parseOptionalSafeEpochString(
       validator.validator.activation_eligibility_epoch,
       'validator.activation_eligibility_epoch',
@@ -553,7 +595,9 @@ export const getBeaconValidators = async (
     return [];
   }
 
-  if (args.validatorIds.some((validatorId) => validatorId.trim().length === 0)) {
+  if (
+    args.validatorIds.some((validatorId) => validatorId.trim().length === 0)
+  ) {
     throw new BeaconValidationError(
       'getBeaconValidators requires every validatorId to be non-empty',
     );
@@ -634,7 +678,8 @@ export const getBeaconValidatorStates = async (
   }
 
   return args.validatorIds.map(
-    (validatorId) => validatorsById.get(toValidatorLookupKey(validatorId)) ?? null,
+    (validatorId) =>
+      validatorsById.get(toValidatorLookupKey(validatorId)) ?? null,
   );
 };
 
@@ -652,7 +697,11 @@ export const waitForBeaconValidatorActivation = async (
     'pollIntervalMs',
     methodName,
   );
-  const timeoutMs = assertPositiveInteger(args.timeoutMs, 'timeoutMs', methodName);
+  const timeoutMs = assertPositiveInteger(
+    args.timeoutMs,
+    'timeoutMs',
+    methodName,
+  );
   const requestTimeoutMs = assertPositiveInteger(
     args.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     'requestTimeoutMs',
@@ -668,7 +717,7 @@ export const waitForBeaconValidatorActivation = async (
       `Timed out waiting for beacon validator activation for ${args.validatorId} after ${timeoutMs}ms; last observed state: ${describeActivationWaitState(lastObservedState)}`,
     );
 
-  while (true) {
+  for (;;) {
     const remainingBudgetMs = deadline - Date.now();
 
     if (remainingBudgetMs <= 0) {

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -617,6 +617,16 @@ const toValidatorLookupKey = (validatorId: string) => {
     : normalized;
 };
 
+// The spec allows any string as a validator id — an unmatched one simply
+// returns no data, "but this will not cause an error" (spec's own words).
+// A dot-segment id is the one shape that breaks that contract: '.' or '..'
+// survives encodeURIComponent unchanged (dots aren't escaped), and the URL
+// pathname setter's standard dot-segment normalization then turns the
+// request into the unfiltered validators collection or an unrelated parent
+// endpoint, silently expanding the query instead of just not matching.
+const isDotSegmentValidatorId = (validatorId: string): boolean =>
+  /^\.+$/.test(validatorId);
+
 // Both the GET and POST validator-batch endpoints require unique transport
 // ids; deduping here (rather than in getBeaconValidatorStates) keeps this a
 // transport-only concern — per-input-position output alignment already comes
@@ -690,6 +700,12 @@ export const getBeaconValidator = async (
     );
   }
 
+  if (isDotSegmentValidatorId(args.validatorId)) {
+    throw new BeaconValidationError(
+      `getBeaconValidator requires a real validatorId, not a dot-segment value ('${args.validatorId}') that URL path normalization would silently redirect elsewhere`,
+    );
+  }
+
   assertFetchableBeaconEndpoint(endpoint, 'getBeaconValidator');
 
   const url = buildBeaconURL(
@@ -746,6 +762,12 @@ export const getBeaconValidators = async (
   ) {
     throw new BeaconValidationError(
       'getBeaconValidators requires every validatorId to be non-empty',
+    );
+  }
+
+  if (args.validatorIds.some(isDotSegmentValidatorId)) {
+    throw new BeaconValidationError(
+      'getBeaconValidators requires every validatorId to be a real id, not a dot-segment value that URL path normalization would silently redirect elsewhere',
     );
   }
 

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -114,6 +114,48 @@ const buildBeaconURL = (endpoint: string, path: string): URL => {
   return url;
 };
 
+// Throws for an endpoint fetch could never use — malformed syntax, an
+// unsupported scheme, or embedded credentials (fetch refuses to construct a
+// Request from a URL with a username/password) — before any caller reaches
+// fetch() with it. Every entry point that accepts a caller-supplied endpoint
+// calls this first: without it, fetch()'s own TypeError for a credentialed
+// URL embeds the URL verbatim in its message, and Node's fetch throws that
+// TypeError however it's called, not just from the retry loop this was
+// originally added for.
+//
+// The reported endpoint is redacted to origin + our own fixed API path,
+// never the caller's own path or query string — a provider's endpoint can
+// embed an API key either way (path-based, e.g. '.../v3/<key>', or
+// query-string, e.g. '?apiKey=<key>'), and neither is safe to echo into an
+// error message, log line, or error tracker. An endpoint that fails to
+// parse at all can still visibly contain a credential (e.g.
+// 'https://user:secret@' is invalid only because the host is missing, not
+// because the credential syntax is), so there's no substring of raw,
+// unparsed input that's safe to assume is clean either — a generic
+// placeholder is reported instead in that case.
+const assertFetchableBeaconEndpoint = (
+  endpoint: string,
+  methodName: string,
+): void => {
+  let reportableEndpoint =
+    '(unparseable endpoint omitted to avoid leaking embedded credentials)';
+
+  try {
+    const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+    reportableEndpoint = `${url.origin}${BEACON_VALIDATORS_PATH}`;
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('unsupported protocol');
+    }
+
+    new Request(url);
+  } catch {
+    throw new BeaconValidationError(
+      `Invalid beacon endpoint for ${methodName}: ${reportableEndpoint}`,
+    );
+  }
+};
+
 // ReadableStream#cancel() can itself reject (e.g. an already-errored stream).
 // Releasing the connection is a best-effort courtesy — it must never replace
 // the meaningful result (a BeaconHttpError, or a 404's null) with whatever
@@ -640,6 +682,8 @@ export const getBeaconValidator = async (
     );
   }
 
+  assertFetchableBeaconEndpoint(endpoint, 'getBeaconValidator');
+
   const url = buildBeaconURL(
     endpoint,
     `${BEACON_VALIDATORS_PATH}/${encodeURIComponent(args.validatorId)}`,
@@ -696,6 +740,8 @@ export const getBeaconValidators = async (
       'getBeaconValidators requires every validatorId to be non-empty',
     );
   }
+
+  assertFetchableBeaconEndpoint(endpoint, 'getBeaconValidators');
 
   const dedupedValidatorIds = dedupeValidatorIds(args.validatorIds);
   const request = getBeaconValidatorsRequest(
@@ -788,42 +834,15 @@ export const waitForBeaconValidatorActivation = async (
 
   const methodName = 'waitForBeaconValidatorActivation';
 
-  // A malformed endpoint, one with a scheme fetch can't handle (e.g.
-  // ftp:/mailto:), or one carrying credentials (fetch refuses to construct a
-  // Request from a URL with a username/password) throws a plain TypeError.
-  // isRetryableActivationError treats that as retryable by default, so left
-  // unchecked, this silently retries a failure that can never succeed for
-  // the entire timeoutMs instead of failing immediately. This deliberately
-  // doesn't cover every way fetch can reject a syntactically valid endpoint
-  // (e.g. a Fetch-spec-blocked port) — those are handled in
+  // Without this, a malformed/unfetchable endpoint throws a plain TypeError
+  // from the first poll's fetch, which isRetryableActivationError treats as
+  // retryable by default — silently retrying a failure that can never
+  // succeed for the entire timeoutMs instead of failing immediately. This
+  // deliberately doesn't cover every way fetch can reject a syntactically
+  // valid endpoint (e.g. a Fetch-spec-blocked port) — those are handled in
   // isRetryableActivationError instead, since they can only be observed by
   // actually attempting the request.
-  // An endpoint that fails to parse at all can still visibly contain a
-  // credential or query secret (e.g. 'https://user:secret@' — invalid only
-  // because the host is missing, not because the credential syntax is), so
-  // there's no substring of raw, unparsed input that's safe to assume is
-  // clean. Report a generic placeholder until buildBeaconURL succeeds and
-  // this is replaced with a redacted origin + pathname before any check
-  // that could reject a credentialed or query-string-auth endpoint (see
-  // below) — either way, a password or API key never reaches an error
-  // message, log line, or error tracker.
-  let reportableEndpoint =
-    '(unparseable endpoint omitted to avoid leaking embedded credentials)';
-
-  try {
-    const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
-    reportableEndpoint = `${url.origin}${url.pathname}`;
-
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      throw new Error('unsupported protocol');
-    }
-
-    new Request(url);
-  } catch {
-    throw new BeaconValidationError(
-      `Invalid beacon endpoint for ${methodName}: ${reportableEndpoint}`,
-    );
-  }
+  assertFetchableBeaconEndpoint(endpoint, methodName);
 
   // pollIntervalMs/requestTimeoutMs are passed to setTimeout-based timers and
   // so are bounded by MAX_TIMER_DELAY_MS; timeoutMs is only ever used for

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -61,7 +61,10 @@ export type WaitForBeaconValidatorActivationArgs = {
   timeoutMs: number;
   failOnNotFound?: boolean;
   // Caps each individual poll attempt so one stalled request can't consume
-  // the whole activation budget. Defaults to pollIntervalMs.
+  // the whole activation budget. Defaults to DEFAULT_REQUEST_TIMEOUT_MS —
+  // deliberately independent of pollIntervalMs, since a short poll interval
+  // is a statement about how often to check, not how long a single healthy
+  // response is allowed to take.
   requestTimeoutMs?: number;
 };
 
@@ -92,6 +95,9 @@ const BEACON_FAR_FUTURE_EPOCH = 18446744073709551615n;
 const BEACON_VALIDATORS_PATH = '/eth/v1/beacon/states/head/validators';
 const BEACON_GET_VALIDATORS_MAX_URL_LENGTH = 7000;
 const BEACON_GET_VALIDATORS_MAX_COUNT = 64;
+// Generous default per-attempt budget for waitForBeaconValidatorActivation —
+// independent of pollIntervalMs, which only controls check frequency.
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 const missingBeaconEndpointError = () =>
   new Error(
@@ -108,7 +114,7 @@ const assertBeaconData = <T>(
     );
   }
 
-  if (typeof payload.data === 'undefined') {
+  if (payload.data === null || typeof payload.data === 'undefined') {
     throw new BeaconValidationError(
       `Beacon API response is missing data for ${methodName}`,
     );
@@ -631,7 +637,7 @@ export const waitForBeaconValidatorActivation = async (
   );
   const timeoutMs = assertPositiveInteger(args.timeoutMs, 'timeoutMs', methodName);
   const requestTimeoutMs = assertPositiveInteger(
-    args.requestTimeoutMs ?? pollIntervalMs,
+    args.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     'requestTimeoutMs',
     methodName,
   );

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -798,12 +798,17 @@ export const waitForBeaconValidatorActivation = async (
   // (e.g. a Fetch-spec-blocked port) — those are handled in
   // isRetryableActivationError instead, since they can only be observed by
   // actually attempting the request.
-  // Reported only on a parse failure, where there's nothing to redact yet —
-  // once buildBeaconURL succeeds, this is replaced with a redacted form
-  // before any check that could reject a credentialed or query-string-auth
-  // endpoint (see below), so a password or API key never reaches an error
+  // An endpoint that fails to parse at all can still visibly contain a
+  // credential or query secret (e.g. 'https://user:secret@' — invalid only
+  // because the host is missing, not because the credential syntax is), so
+  // there's no substring of raw, unparsed input that's safe to assume is
+  // clean. Report a generic placeholder until buildBeaconURL succeeds and
+  // this is replaced with a redacted origin + pathname before any check
+  // that could reject a credentialed or query-string-auth endpoint (see
+  // below) — either way, a password or API key never reaches an error
   // message, log line, or error tracker.
-  let reportableEndpoint = endpoint;
+  let reportableEndpoint =
+    '(unparseable endpoint omitted to avoid leaking embedded credentials)';
 
   try {
     const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -114,6 +114,18 @@ const buildBeaconURL = (endpoint: string, path: string): URL => {
   return url;
 };
 
+// ReadableStream#cancel() can itself reject (e.g. an already-errored stream).
+// Releasing the connection is a best-effort courtesy — it must never replace
+// the meaningful result (a BeaconHttpError, or a 404's null) with whatever
+// cancellation itself failed with.
+const cancelResponseBody = async (response: Response): Promise<void> => {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Ignored — see rationale above.
+  }
+};
+
 const missingBeaconEndpointError = () =>
   new Error(
     'Beacon endpoint is not configured. Provide extendedConfig.beacon.endpoint in SDK config.',
@@ -425,6 +437,25 @@ const isRetryableActivationError = (error: unknown): boolean => {
     return RETRYABLE_HTTP_STATUSES.has(error.status) || error.status >= 500;
   }
 
+  // undici's fetch throws a generic TypeError for a syntactically valid
+  // endpoint on a Fetch-spec-blocked port (e.g. :25) — a permanent config
+  // error masquerading as a network failure, with this exact cause message
+  // as the only distinguishing signal. Deliberately narrow: every other
+  // TypeError from fetch (DNS failures, connection resets, etc.) must stay
+  // retryable, so only this specific cause is excluded, not TypeError as a
+  // whole.
+  // Error#cause is ES2022; this repo targets ES2020, so the type isn't on
+  // the lib's Error/TypeError declarations even though Node sets it.
+  const cause = (error as { cause?: unknown }).cause;
+
+  if (
+    error instanceof TypeError &&
+    cause instanceof Error &&
+    cause.message === 'bad port'
+  ) {
+    return false;
+  }
+
   return true;
 };
 
@@ -622,7 +653,7 @@ export const getBeaconValidator = async (
     // failOnNotFound, this is the branch waitForBeaconValidatorActivation
     // takes on every poll until the validator appears, so it's the
     // higher-frequency path for an uncancelled body to accumulate on.
-    await response.body?.cancel();
+    await cancelResponseBody(response);
     return null;
   }
 
@@ -630,7 +661,7 @@ export const getBeaconValidator = async (
     // Release the connection back to the pool instead of leaving the body
     // unconsumed — this path runs on every retried poll against an unhealthy
     // endpoint, so an uncancelled body here accumulates across a long wait.
-    await response.body?.cancel();
+    await cancelResponseBody(response);
     throw new BeaconHttpError(
       response.status,
       `Beacon API request failed for getBeaconValidator with status ${response.status}`,
@@ -681,7 +712,7 @@ export const getBeaconValidators = async (
   // here means the state/route itself is wrong (e.g. misconfigured
   // endpoint), so it must not be swallowed into an empty result.
   if (!response.ok) {
-    await response.body?.cancel();
+    await cancelResponseBody(response);
     throw new BeaconHttpError(
       response.status,
       `Beacon API request failed for getBeaconValidators with status ${response.status}`,
@@ -757,18 +788,24 @@ export const waitForBeaconValidatorActivation = async (
 
   const methodName = 'waitForBeaconValidatorActivation';
 
-  // A malformed endpoint (or one with a scheme fetch can't handle, e.g.
-  // ftp:/mailto:) throws a plain TypeError — from buildBeaconURL, or later
-  // from fetch itself for an otherwise-valid URL with an unsupported scheme.
+  // A malformed endpoint, one with a scheme fetch can't handle (e.g.
+  // ftp:/mailto:), or one carrying credentials (fetch refuses to construct a
+  // Request from a URL with a username/password) throws a plain TypeError.
   // isRetryableActivationError treats that as retryable by default, so left
   // unchecked, this silently retries a failure that can never succeed for
-  // the entire timeoutMs instead of failing immediately.
+  // the entire timeoutMs instead of failing immediately. This deliberately
+  // doesn't cover every way fetch can reject a syntactically valid endpoint
+  // (e.g. a Fetch-spec-blocked port) — those are handled in
+  // isRetryableActivationError instead, since they can only be observed by
+  // actually attempting the request.
   try {
     const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       throw new Error('unsupported protocol');
     }
+
+    new Request(url);
   } catch {
     throw new BeaconValidationError(
       `Invalid beacon endpoint for ${methodName}: ${endpoint}`,

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -618,6 +618,11 @@ export const getBeaconValidator = async (
     : await fetch(url);
 
   if (response.status === 404) {
+    // Same rationale as the !response.ok branch below: without
+    // failOnNotFound, this is the branch waitForBeaconValidatorActivation
+    // takes on every poll until the validator appears, so it's the
+    // higher-frequency path for an uncancelled body to accumulate on.
+    await response.body?.cancel();
     return null;
   }
 

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -205,6 +205,23 @@ const sleep = (delayMs: number) =>
     setTimeout(resolve, delayMs);
   });
 
+// Native AbortSignal.timeout() schedules through an internal timer rather
+// than the global setTimeout, so it can't be advanced deterministically by
+// swapping the timer implementation in tests. Building it from setTimeout
+// keeps a stalled request abortable within the caller's time budget while
+// staying controllable by such tests.
+const createBudgetSignal = (budgetMs: number) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => {
+    controller.abort(new Error(`Beacon request exceeded its ${budgetMs}ms time budget`));
+  }, budgetMs);
+
+  return {
+    signal: controller.signal,
+    dispose: () => clearTimeout(timeoutId),
+  };
+};
+
 const describeActivationWaitState = (state: BeaconValidatorState | null) => {
   if (state === null) {
     return 'not found';
@@ -327,18 +344,25 @@ const getBeaconValidatorsRequest = (
 
 export const getBeaconValidator = async (
   endpoint: string | undefined,
-  args: { validatorId: string },
+  args: { validatorId: string; signal?: AbortSignal },
 ): Promise<BeaconValidator | null> => {
   if (!endpoint) {
     throw missingBeaconEndpointError();
   }
 
-  const response = await fetch(
-    join(
-      endpoint,
-      `/eth/v1/beacon/states/head/validators/${encodeURIComponent(args.validatorId)}`,
-    ),
+  if (args.validatorId.trim().length === 0) {
+    throw new Error(
+      'getBeaconValidator requires a non-empty validatorId; an empty value would request the unfiltered validator list instead',
+    );
+  }
+
+  const url = join(
+    endpoint,
+    `/eth/v1/beacon/states/head/validators/${encodeURIComponent(args.validatorId)}`,
   );
+  const response = args.signal
+    ? await fetch(url, { signal: args.signal })
+    : await fetch(url);
 
   if (response.status === 404) {
     return null;
@@ -373,10 +397,10 @@ export const getBeaconValidators = async (
     ? await fetch(request.url, request.init)
     : await fetch(request.url);
 
-  if (response.status === 404) {
-    return [];
-  }
-
+  // Unlike the single-validator route, the batch route returns 200 with a
+  // filtered (possibly empty) list for validators that don't exist. A 404
+  // here means the state/route itself is wrong (e.g. misconfigured
+  // endpoint), so it must not be swallowed into an empty result.
   if (!response.ok) {
     throw new Error(
       `Beacon API request failed for getBeaconValidators with status ${response.status}`,
@@ -399,7 +423,7 @@ export const getBeaconValidators = async (
 
 export const getBeaconValidatorState = async (
   endpoint: string | undefined,
-  args: { validatorId: string },
+  args: { validatorId: string; signal?: AbortSignal },
 ): Promise<BeaconValidatorState | null> => {
   const validator = await getBeaconValidator(endpoint, args);
 
@@ -459,10 +483,43 @@ export const waitForBeaconValidatorActivation = async (
   const deadline = Date.now() + timeoutMs;
   let lastObservedState: BeaconValidatorState | null = null;
 
+  const timeoutError = () =>
+    new Error(
+      `Timed out waiting for beacon validator activation for ${args.validatorId} after ${timeoutMs}ms; last observed state: ${describeActivationWaitState(lastObservedState)}`,
+    );
+
   while (true) {
-    const state = await getBeaconValidatorState(endpoint, {
-      validatorId: args.validatorId,
-    });
+    const remainingBudgetMs = deadline - Date.now();
+
+    if (remainingBudgetMs <= 0) {
+      throw timeoutError();
+    }
+
+    // Bound each attempt by the remaining budget so a stalled request can't
+    // block the wait past timeoutMs, and retry transient fetch failures
+    // (network errors, 429/5xx, this abort) instead of rejecting the whole
+    // wait on a single blip.
+    const { signal, dispose } = createBudgetSignal(remainingBudgetMs);
+    let state: BeaconValidatorState | null;
+
+    try {
+      state = await getBeaconValidatorState(endpoint, {
+        validatorId: args.validatorId,
+        signal,
+      });
+    } catch (error) {
+      const remainingMs = deadline - Date.now();
+
+      if (remainingMs <= 0) {
+        throw error;
+      }
+
+      await sleep(Math.min(pollIntervalMs, remainingMs));
+      continue;
+    } finally {
+      dispose();
+    }
+
     lastObservedState = state;
 
     if (state === null && args.failOnNotFound) {
@@ -488,9 +545,7 @@ export const waitForBeaconValidatorActivation = async (
     const remainingMs = deadline - Date.now();
 
     if (remainingMs <= 0) {
-      throw new Error(
-        `Timed out waiting for beacon validator activation for ${args.validatorId} after ${timeoutMs}ms; last observed state: ${describeActivationWaitState(lastObservedState)}`,
-      );
+      throw timeoutError();
     }
 
     await sleep(Math.min(pollIntervalMs, remainingMs));

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -622,6 +622,10 @@ export const getBeaconValidator = async (
   }
 
   if (!response.ok) {
+    // Release the connection back to the pool instead of leaving the body
+    // unconsumed — this path runs on every retried poll against an unhealthy
+    // endpoint, so an uncancelled body here accumulates across a long wait.
+    await response.body?.cancel();
     throw new BeaconHttpError(
       response.status,
       `Beacon API request failed for getBeaconValidator with status ${response.status}`,
@@ -672,6 +676,7 @@ export const getBeaconValidators = async (
   // here means the state/route itself is wrong (e.g. misconfigured
   // endpoint), so it must not be swallowed into an empty result.
   if (!response.ok) {
+    await response.body?.cancel();
     throw new BeaconHttpError(
       response.status,
       `Beacon API request failed for getBeaconValidators with status ${response.status}`,

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -1,5 +1,3 @@
-import join from '@/utils/url-join';
-
 export type BeaconValidator = {
   index: string | null;
   balance: string;
@@ -102,6 +100,19 @@ const BEACON_GET_VALIDATORS_MAX_COUNT = 64;
 // Generous default per-attempt budget for waitForBeaconValidatorActivation —
 // independent of pollIntervalMs, which only controls check frequency.
 const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+// The shared url-join utility appends the path *after* an existing query
+// string (e.g. a provider endpoint configured as
+// 'https://host?apiKey=secret' would produce '...?apiKey=secret/eth/v1/...'),
+// silently breaking any endpoint with query-string auth. Build on the
+// pathname directly instead, which naturally preserves the endpoint's own
+// query params so they can be merged with (not clobbered by) route-specific
+// ones like the batch GET's id[].
+const buildBeaconURL = (endpoint: string, path: string): URL => {
+  const url = new URL(endpoint);
+  url.pathname = `${url.pathname.replace(/\/+$/, '')}${path}`;
+  return url;
+};
 
 const missingBeaconEndpointError = () =>
   new Error(
@@ -350,6 +361,31 @@ const assertPositiveInteger = (
   return value;
 };
 
+// setTimeout (and AbortSignal-based timers built on it) silently clamps any
+// delay above the 32-bit signed int max down to ~1ms instead of throwing, so
+// a valid-looking multi-week value would fire almost immediately and busy-loop
+// instead of waiting. This only applies to values that actually reach a timer
+// (pollIntervalMs, requestTimeoutMs) — timeoutMs itself is just deadline
+// arithmetic (Date.now() + timeoutMs) and can be arbitrarily large, since
+// every timer derived from it is separately bounded by one of these two.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+const assertPositiveTimerDelay = (
+  value: number,
+  fieldName: string,
+  methodName: string,
+) => {
+  const validated = assertPositiveInteger(value, fieldName, methodName);
+
+  if (validated > MAX_TIMER_DELAY_MS) {
+    throw new BeaconValidationError(
+      `Invalid ${fieldName} for ${methodName}: expected a positive integer number of milliseconds no greater than ${MAX_TIMER_DELAY_MS}`,
+    );
+  }
+
+  return validated;
+};
+
 const sleep = (delayMs: number) =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, delayMs);
@@ -486,7 +522,19 @@ const mapBeaconValidatorState = (
   };
 };
 
-const toValidatorLookupKey = (validatorId: string) => validatorId.toLowerCase();
+// Response-derived index keys are always canonical decimal (they're built via
+// String(number)), but a caller-supplied index string might not be (e.g.
+// '0012'). Canonicalize plain-decimal lookups so both sides match; pubkeys
+// (0x-prefixed hex) never match the digits-only check and fall through
+// to a plain case-insensitive compare.
+const DECIMAL_LOOKUP_KEY_PATTERN = /^[0-9]+$/;
+
+const toValidatorLookupKey = (validatorId: string) => {
+  const normalized = validatorId.toLowerCase();
+  return DECIMAL_LOOKUP_KEY_PATTERN.test(normalized)
+    ? String(Number(normalized))
+    : normalized;
+};
 
 // Both the GET and POST validator-batch endpoints require unique transport
 // ids; deduping here (rather than in getBeaconValidatorStates) keeps this a
@@ -498,10 +546,16 @@ const dedupeValidatorIds = (validatorIds: string[]): string[] =>
 
 // Only ever called with a non-empty, deduped id list (getBeaconValidators
 // early-returns before this point for an empty batch), so no empty-array case.
-const getBeaconValidatorsURL = (endpoint: string, validatorIds: string[]) =>
-  `${join(endpoint, BEACON_VALIDATORS_PATH)}?${validatorIds
+const getBeaconValidatorsURL = (endpoint: string, validatorIds: string[]) => {
+  const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+  const idQuery = validatorIds
     .map((validatorId) => `id=${encodeURIComponent(validatorId)}`)
-    .join('&')}`;
+    .join('&');
+  // Merge onto (rather than replace) any query the endpoint already carries.
+  const existingQuery = url.search.replace(/^\?/, '');
+  url.search = [existingQuery, idQuery].filter(Boolean).join('&');
+  return url.toString();
+};
 
 const getBeaconValidatorsRequest = (
   endpoint: string,
@@ -526,7 +580,7 @@ const getBeaconValidatorsRequest = (
   }
 
   return {
-    url: join(endpoint, BEACON_VALIDATORS_PATH),
+    url: buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH).toString(),
     init: {
       method: 'POST',
       headers: {
@@ -555,10 +609,10 @@ export const getBeaconValidator = async (
     );
   }
 
-  const url = join(
+  const url = buildBeaconURL(
     endpoint,
-    `/eth/v1/beacon/states/head/validators/${encodeURIComponent(args.validatorId)}`,
-  );
+    `${BEACON_VALIDATORS_PATH}/${encodeURIComponent(args.validatorId)}`,
+  ).toString();
   const response = args.signal
     ? await fetch(url, { signal: args.signal })
     : await fetch(url);
@@ -692,7 +746,10 @@ export const waitForBeaconValidatorActivation = async (
   }
 
   const methodName = 'waitForBeaconValidatorActivation';
-  const pollIntervalMs = assertPositiveInteger(
+  // pollIntervalMs/requestTimeoutMs are passed to setTimeout-based timers and
+  // so are bounded by MAX_TIMER_DELAY_MS; timeoutMs is only ever used for
+  // Date.now()-based deadline arithmetic and can be arbitrarily large.
+  const pollIntervalMs = assertPositiveTimerDelay(
     args.pollIntervalMs,
     'pollIntervalMs',
     methodName,
@@ -702,7 +759,7 @@ export const waitForBeaconValidatorActivation = async (
     'timeoutMs',
     methodName,
   );
-  const requestTimeoutMs = assertPositiveInteger(
+  const requestTimeoutMs = assertPositiveTimerDelay(
     args.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
     'requestTimeoutMs',
     methodName,

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -757,12 +757,18 @@ export const waitForBeaconValidatorActivation = async (
 
   const methodName = 'waitForBeaconValidatorActivation';
 
-  // A malformed endpoint throws a plain TypeError from buildBeaconURL, which
-  // isRetryableActivationError treats as retryable by default — left
-  // unchecked, that silently retries a failure that can never succeed for
+  // A malformed endpoint (or one with a scheme fetch can't handle, e.g.
+  // ftp:/mailto:) throws a plain TypeError — from buildBeaconURL, or later
+  // from fetch itself for an otherwise-valid URL with an unsupported scheme.
+  // isRetryableActivationError treats that as retryable by default, so left
+  // unchecked, this silently retries a failure that can never succeed for
   // the entire timeoutMs instead of failing immediately.
   try {
-    buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+    const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      throw new Error('unsupported protocol');
+    }
   } catch {
     throw new BeaconValidationError(
       `Invalid beacon endpoint for ${methodName}: ${endpoint}`,

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -123,10 +123,20 @@ const parseBeaconJSON = async <T>(
 ): Promise<BeaconResponse<T>> => {
   try {
     return (await response.json()) as BeaconResponse<T>;
-  } catch {
-    throw new BeaconValidationError(
-      `Beacon API returned invalid JSON for ${methodName}`,
-    );
+  } catch (error) {
+    // response.json() rejects both for malformed JSON content (SyntaxError,
+    // once the body has been read in full) and for a body read that never
+    // completes (connection drop, or our own attempt-timeout abort firing
+    // mid-stream). Only the former is a permanent, non-retryable failure —
+    // the latter must propagate as-is so isRetryableActivationError's
+    // default (retryable) applies.
+    if (error instanceof SyntaxError) {
+      throw new BeaconValidationError(
+        `Beacon API returned invalid JSON for ${methodName}`,
+      );
+    }
+
+    throw error;
   }
 };
 

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -142,7 +142,15 @@ const assertFetchableBeaconEndpoint = (
 
   try {
     const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
-    reportableEndpoint = `${url.origin}${BEACON_VALIDATORS_PATH}`;
+
+    // An opaque-path scheme (a typo like 'htttps:', or a non-special scheme
+    // like 'mailto:'/'admin:') serializes url.origin as the literal string
+    // 'null' — not a credential leak on its own, but concatenating it would
+    // produce a confusing 'null/eth/v1/...' message. Keep the placeholder
+    // instead for anything without a real origin to report.
+    if (url.origin !== 'null') {
+      reportableEndpoint = `${url.origin}${BEACON_VALIDATORS_PATH}`;
+    }
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       throw new Error('unsupported protocol');

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -798,8 +798,16 @@ export const waitForBeaconValidatorActivation = async (
   // (e.g. a Fetch-spec-blocked port) — those are handled in
   // isRetryableActivationError instead, since they can only be observed by
   // actually attempting the request.
+  // Reported only on a parse failure, where there's nothing to redact yet —
+  // once buildBeaconURL succeeds, this is replaced with a redacted form
+  // before any check that could reject a credentialed or query-string-auth
+  // endpoint (see below), so a password or API key never reaches an error
+  // message, log line, or error tracker.
+  let reportableEndpoint = endpoint;
+
   try {
     const url = buildBeaconURL(endpoint, BEACON_VALIDATORS_PATH);
+    reportableEndpoint = `${url.origin}${url.pathname}`;
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       throw new Error('unsupported protocol');
@@ -808,7 +816,7 @@ export const waitForBeaconValidatorActivation = async (
     new Request(url);
   } catch {
     throw new BeaconValidationError(
-      `Invalid beacon endpoint for ${methodName}: ${endpoint}`,
+      `Invalid beacon endpoint for ${methodName}: ${reportableEndpoint}`,
     );
   }
 

--- a/src/api/beacon/index.ts
+++ b/src/api/beacon/index.ts
@@ -1,7 +1,7 @@
 import join from '@/utils/url-join';
 
 export type BeaconValidator = {
-  index: string;
+  index: string | null;
   balance: string;
   status: string;
   validator: {
@@ -59,6 +59,7 @@ export type WaitForBeaconValidatorActivationArgs = {
   validatorId: string;
   pollIntervalMs: number;
   timeoutMs: number;
+  failOnNotFound?: boolean;
 };
 
 type BeaconResponse<T> = {
@@ -68,6 +69,7 @@ type BeaconResponse<T> = {
 // Beacon APIs use the uint64 max value as a sentinel for epochs that are not set yet.
 const BEACON_FAR_FUTURE_EPOCH = 18446744073709551615n;
 const BEACON_VALIDATORS_PATH = '/eth/v1/beacon/states/head/validators';
+const BEACON_GET_VALIDATORS_MAX_URL_LENGTH = 7000;
 
 const missingBeaconEndpointError = () =>
   new Error(
@@ -298,6 +300,31 @@ const getBeaconValidatorsURL = (
     .join('&')}`;
 };
 
+const getBeaconValidatorsRequest = (
+  endpoint: string,
+  validatorIds: string[],
+): { url: string; init?: RequestInit } => {
+  const url = getBeaconValidatorsURL(endpoint, validatorIds);
+
+  // Long validator ids can exceed provider or proxy URL limits before batch size does.
+  if (url.length <= BEACON_GET_VALIDATORS_MAX_URL_LENGTH) {
+    return {
+      url,
+    };
+  }
+
+  return {
+    url: join(endpoint, BEACON_VALIDATORS_PATH),
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ids: validatorIds }),
+    },
+  };
+};
+
 export const getBeaconValidator = async (
   endpoint: string | undefined,
   args: { validatorId: string },
@@ -341,9 +368,10 @@ export const getBeaconValidators = async (
     return [];
   }
 
-  const response = await fetch(
-    getBeaconValidatorsURL(endpoint, args.validatorIds),
-  );
+  const request = getBeaconValidatorsRequest(endpoint, args.validatorIds);
+  const response = request.init
+    ? await fetch(request.url, request.init)
+    : await fetch(request.url);
 
   if (response.status === 404) {
     return [];
@@ -386,10 +414,6 @@ export const getBeaconValidatorStates = async (
   endpoint: string | undefined,
   args: { validatorIds: string[] },
 ): Promise<Array<BeaconValidatorState | null>> => {
-  if (args.validatorIds.length === 0) {
-    return [];
-  }
-
   const validators = await getBeaconValidators(endpoint, args);
   const validatorsById = new Map<string, BeaconValidatorState>();
 
@@ -440,6 +464,12 @@ export const waitForBeaconValidatorActivation = async (
       validatorId: args.validatorId,
     });
     lastObservedState = state;
+
+    if (state === null && args.failOnNotFound) {
+      throw new Error(
+        `Beacon validator ${args.validatorId} was not found while waiting for activation`,
+      );
+    }
 
     if (state !== null) {
       const lifecycleStage = getBeaconValidatorLifecycleStage(state);

--- a/src/config/create.ts
+++ b/src/config/create.ts
@@ -51,17 +51,34 @@ export type ConfigReturnType = {
   };
 };
 
+const isNonNullObject = (
+  value: unknown,
+): value is Record<PropertyKey, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
 export const isConfig = (props: unknown): props is ConfigReturnType => {
+  if (!isNonNullObject(props)) {
+    return false;
+  }
+
   return (
-    typeof props === 'object' &&
-    props !== null &&
     'publicClient' in props &&
+    isNonNullObject(props.publicClient) &&
     'chain' in props &&
+    isNonNullObject(props.chain) &&
     'api' in props &&
+    isNonNullObject(props.api) &&
     'contractAddresses' in props &&
+    isNonNullObject(props.contractAddresses) &&
     'contract' in props &&
+    isNonNullObject(props.contract) &&
     'subgraph' in props &&
-    'rest' in props
+    isNonNullObject(props.subgraph) &&
+    'rest' in props &&
+    isNonNullObject(props.rest) &&
+    'beacon' in props &&
+    isNonNullObject(props.beacon)
   );
 };
 

--- a/src/config/create.ts
+++ b/src/config/create.ts
@@ -61,8 +61,7 @@ export const isConfig = (props: unknown): props is ConfigReturnType => {
     'contractAddresses' in props &&
     'contract' in props &&
     'subgraph' in props &&
-    'rest' in props &&
-    'beacon' in props
+    'rest' in props
   );
 };
 

--- a/src/config/create.ts
+++ b/src/config/create.ts
@@ -51,7 +51,7 @@ export type ConfigReturnType = {
   };
 };
 
-const isNonNullObject = (
+export const isNonNullObject = (
   value: unknown,
 ): value is Record<PropertyKey, unknown> => {
   return typeof value === 'object' && value !== null;

--- a/src/config/create.ts
+++ b/src/config/create.ts
@@ -54,7 +54,9 @@ export type ConfigReturnType = {
 export const isNonNullObject = (
   value: unknown,
 ): value is Record<PropertyKey, unknown> => {
-  return typeof value === 'object' && value !== null;
+  // typeof [] === 'object' in JS, so arrays must be excluded explicitly —
+  // otherwise e.g. isConfig({...validConfig, beacon: []}) would pass.
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 };
 
 export const isConfig = (props: unknown): props is ConfigReturnType => {

--- a/src/config/create.ts
+++ b/src/config/create.ts
@@ -7,7 +7,7 @@ import type {
   ReaderFunctions,
   WriterFunctions,
 } from '@/contract-interactions/types';
-import { createQueries, createSSVAPI } from '@/libs/api';
+import { createBeaconAPI, createQueries, createSSVAPI } from '@/libs/api';
 import type { ConfigArgs } from '@/utils/zod/config';
 import { configArgsSchema } from '@/utils/zod/config';
 import { GraphQLClient } from 'graphql-request';
@@ -24,7 +24,9 @@ export type ConfigReturnType = {
   publicClient: PublicClient;
   walletClient?: WalletClient;
   chain: Chain;
-  api: ReturnType<typeof createQueries> & ReturnType<typeof createSSVAPI>;
+  api: ReturnType<typeof createQueries> &
+    ReturnType<typeof createSSVAPI> &
+    ReturnType<typeof createBeaconAPI>;
   contractAddresses: {
     setter: Address;
     getter: Address;
@@ -44,6 +46,9 @@ export type ConfigReturnType = {
   rest: {
     endpoint: string;
   };
+  beacon: {
+    endpoint?: string;
+  };
 };
 
 export const isConfig = (props: unknown): props is ConfigReturnType => {
@@ -56,7 +61,8 @@ export const isConfig = (props: unknown): props is ConfigReturnType => {
     'contractAddresses' in props &&
     'contract' in props &&
     'subgraph' in props &&
-    'rest' in props
+    'rest' in props &&
+    'beacon' in props
   );
 };
 
@@ -144,6 +150,8 @@ export const createConfig = (props: ConfigArgs): ConfigReturnType => {
   const restEndpoint =
     extendedConfig?.rest?.endpoint || rest_endpoints[chainId];
 
+  const beaconEndpoint = extendedConfig?.beacon?.endpoint;
+
   const graphQLClient = new GraphQLClient(
     graphEndpoint,
     hasAPIKey
@@ -162,6 +170,7 @@ export const createConfig = (props: ConfigArgs): ConfigReturnType => {
     api: {
       ...createQueries(graphQLClient),
       ...createSSVAPI(restEndpoint),
+      ...createBeaconAPI(beaconEndpoint),
     },
     subgraph: {
       client: graphQLClient,
@@ -169,6 +178,9 @@ export const createConfig = (props: ConfigArgs): ConfigReturnType => {
     },
     rest: {
       endpoint: restEndpoint,
+    },
+    beacon: {
+      endpoint: beaconEndpoint,
     },
     contractAddresses: addresses,
     contract,

--- a/src/libs/api/index.ts
+++ b/src/libs/api/index.ts
@@ -1,3 +1,4 @@
+import { getBeaconAPI } from '@/api/beacon';
 import { getSSVAPI } from '@/api/ssv-api';
 import { getQueries } from '@/api/subgraph';
 import type { GraphQLClient } from 'graphql-request';
@@ -8,4 +9,8 @@ export const createQueries = (graphqlClient: GraphQLClient) => {
 
 export const createSSVAPI = (endpoint: string) => {
   return getSSVAPI(endpoint);
+};
+
+export const createBeaconAPI = (endpoint?: string) => {
+  return getBeaconAPI(endpoint);
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+export * from '@/api/beacon';
 export * from '@/api/subgraph';
 export * from '@/config';
 export * from '@/contract-interactions';

--- a/src/mock/api.ts
+++ b/src/mock/api.ts
@@ -12,7 +12,7 @@ export const createMockApi = (
   publicClient: PublicClient,
 ): ConfigReturnType['api'] => {
   const defaultBeaconValidatorState: BeaconValidatorState = {
-    publicKey: '0xmock-beacon-validator',
+    publicKey: `0x${'deadbeef'.repeat(12)}`,
     validatorIndex: 0,
     status: 'active',
     rawStatus: 'active_ongoing',

--- a/src/mock/api.ts
+++ b/src/mock/api.ts
@@ -1,3 +1,7 @@
+import {
+  getBeaconValidatorLifecycleStage,
+  type BeaconValidatorState,
+} from '@/api/beacon';
 import { MainnetV4SetterABI } from '@/abi/mainnet/v4/setter';
 import type { ConfigReturnType } from '@/config';
 import { createClusterId } from '@/utils';
@@ -7,6 +11,20 @@ import { vi } from 'vitest';
 export const createMockApi = (
   publicClient: PublicClient,
 ): ConfigReturnType['api'] => {
+  const defaultBeaconValidatorState: BeaconValidatorState = {
+    publicKey: '0xmock-beacon-validator',
+    validatorIndex: 0,
+    status: 'active',
+    rawStatus: 'active_ongoing',
+    balanceGwei: 0n,
+    effectiveBalanceGwei: 0n,
+    slashed: false,
+    activationEligibilityEpoch: 0,
+    activationEpoch: 0,
+    exitEpoch: null,
+    withdrawableEpoch: null,
+  };
+
   const nonces = new Map<string, number>();
   const operators = new Map<
     string,
@@ -106,6 +124,15 @@ export const createMockApi = (
   });
 
   return {
+    checkOperatorDKGEnabled: vi.fn().mockImplementation(
+      (dkgAddresses: Array<{ id: string; address: string }>) =>
+      Promise.resolve(
+        dkgAddresses.map(({ id }) => ({
+          id,
+          isHealthy: true,
+        })),
+      ),
+    ),
     getOwnerNonce: vi.fn().mockImplementation((args) =>
       Promise.resolve({
         blockNumber: typeof args.block === 'number' ? args.block : 1,
@@ -222,5 +249,28 @@ export const createMockApi = (
         },
       });
     }),
-  } as unknown as ConfigReturnType['api'];
+    getDaoValues: vi.fn().mockResolvedValue({
+      blockNumber: 1,
+      daovalues: {
+        networkFee: '100000000000000000',
+        networkFeeIndex: '0',
+        networkFeeIndexBlockNumber: '1',
+        networkFeeSSV: '100000000000000000',
+        networkFeeIndexSSV: '0',
+        networkFeeIndexBlockNumberSSV: '1',
+        liquidationThreshold: '1000000000000000000',
+        liquidationThresholdSSV: '1000000000000000000',
+        minimumLiquidationCollateral: '2000000000000000000',
+        minimumLiquidationCollateralSSV: '2000000000000000000',
+      },
+    }),
+    getBeaconValidator: vi.fn().mockResolvedValue(null),
+    getBeaconValidators: vi.fn().mockResolvedValue([]),
+    getBeaconValidatorState: vi.fn().mockResolvedValue(null),
+    getBeaconValidatorStates: vi.fn().mockResolvedValue([]),
+    getBeaconValidatorLifecycleStage,
+    waitForBeaconValidatorActivation: vi
+      .fn()
+      .mockResolvedValue(defaultBeaconValidatorState),
+  };
 };

--- a/src/mock/api.ts
+++ b/src/mock/api.ts
@@ -267,7 +267,11 @@ export const createMockApi = (
     getBeaconValidator: vi.fn().mockResolvedValue(null),
     getBeaconValidators: vi.fn().mockResolvedValue([]),
     getBeaconValidatorState: vi.fn().mockResolvedValue(null),
-    getBeaconValidatorStates: vi.fn().mockResolvedValue([]),
+    getBeaconValidatorStates: vi
+      .fn()
+      .mockImplementation((args: { validatorIds: string[] }) =>
+        Promise.resolve(args.validatorIds.map(() => null)),
+      ),
     getBeaconValidatorLifecycleStage,
     waitForBeaconValidatorActivation: vi
       .fn()

--- a/src/mock/api.ts
+++ b/src/mock/api.ts
@@ -124,15 +124,17 @@ export const createMockApi = (
   });
 
   return {
-    checkOperatorDKGEnabled: vi.fn().mockImplementation(
-      (dkgAddresses: Array<{ id: string; address: string }>) =>
-      Promise.resolve(
-        dkgAddresses.map(({ id }) => ({
-          id,
-          isHealthy: true,
-        })),
+    checkOperatorDKGEnabled: vi
+      .fn()
+      .mockImplementation(
+        (dkgAddresses: Array<{ id: string; address: string }>) =>
+          Promise.resolve(
+            dkgAddresses.map(({ id }) => ({
+              id,
+              isHealthy: true,
+            })),
+          ),
       ),
-    ),
     getOwnerNonce: vi.fn().mockImplementation((args) =>
       Promise.resolve({
         blockNumber: typeof args.block === 'number' ? args.block : 1,

--- a/src/mock/config.ts
+++ b/src/mock/config.ts
@@ -32,6 +32,9 @@ export const createMockConfig = (args: MockConfigArgs): ConfigReturnType => {
     rest: {
       endpoint: {} as unknown as ConfigReturnType['rest']['endpoint'],
     },
+    beacon: {
+      endpoint: undefined,
+    },
     contractAddresses: args.addresses,
   };
 };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -83,7 +83,8 @@ const hasIncompletePrebuiltConfigShape = (props: unknown): boolean => {
     (key) => key in props,
   );
 
-  // isConfig validates every field's presence and shape symmetrically, so
+  // isConfig checks every field's presence and top-level shape symmetrically
+  // (it doesn't validate nested values like beacon.endpoint's type), so
   // reuse it here instead of re-deriving which one field is broken — a
   // prebuilt-looking object that fails isConfig for ANY reason (not just an
   // invalid beacon) must not silently fall through to createConfig, which

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -18,7 +18,18 @@ export class SSVSDK {
   readonly utils: ReturnType<typeof createUtils>;
 
   constructor(props: ConfigArgs | ConfigReturnType) {
-    this.config = isConfig(props) ? props : createConfig(props);
+    if (isConfig(props)) {
+      this.config = props;
+    } else {
+      if (hasIncompletePrebuiltConfigShape(props)) {
+        throw new Error(
+          'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.',
+        );
+      }
+
+      this.config = createConfig(props);
+    }
+
     this.clusters = createClusterManager(this.config);
     this.dao = createDaoManager(this.config);
     this.operators = createOperatorManager(this.config);
@@ -44,3 +55,26 @@ export class SSVSDK {
     return this;
   }
 }
+
+const isNonNullObject = (
+  value: unknown,
+): value is Record<PropertyKey, unknown> => {
+  return typeof value === 'object' && value !== null;
+};
+
+const hasIncompletePrebuiltConfigShape = (props: unknown): boolean => {
+  if (!isNonNullObject(props)) {
+    return false;
+  }
+
+  return (
+    'publicClient' in props &&
+    'chain' in props &&
+    'api' in props &&
+    'contractAddresses' in props &&
+    'contract' in props &&
+    'subgraph' in props &&
+    'rest' in props &&
+    !('beacon' in props)
+  );
+};

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -79,7 +79,9 @@ const hasIncompletePrebuiltConfigShape = (props: unknown): boolean => {
     return false;
   }
 
-  const looksPrebuilt = CONFIG_RETURN_TYPE_ONLY_KEYS.some((key) => key in props);
+  const looksPrebuilt = CONFIG_RETURN_TYPE_ONLY_KEYS.some(
+    (key) => key in props,
+  );
 
   // isConfig validates every field's presence and shape symmetrically, so
   // reuse it here instead of re-deriving which one field is broken — a

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -4,7 +4,12 @@ import { createOperatorManager } from '@/libs/operator';
 import { createUtils } from '@/libs/utils';
 import type { WalletClient } from 'viem';
 import type { ConfigReturnType } from '@/config';
-import { createConfig, createContractInteractions, isConfig } from '@/config';
+import {
+  createConfig,
+  createContractInteractions,
+  isConfig,
+  isNonNullObject,
+} from '@/config';
 import type { ConfigArgs } from '@/utils';
 import { configArgsSchema } from '@/utils';
 
@@ -23,7 +28,7 @@ export class SSVSDK {
     } else {
       if (hasIncompletePrebuiltConfigShape(props)) {
         throw new Error(
-          'Incomplete prebuilt config object: normalized SDK configs must include a beacon field. The normalized beacon shape is required even when beacon.endpoint is undefined.',
+          'Incomplete prebuilt config object: this looks like a normalized SDK config but is missing or has an invalid value for one of its required fields (publicClient, chain, api, contractAddresses, contract, subgraph, rest, beacon). Provide a complete config object, or pass ConfigArgs (publicClient/walletClient/extendedConfig) instead.',
         );
       }
 
@@ -56,25 +61,30 @@ export class SSVSDK {
   }
 }
 
-const isNonNullObject = (
-  value: unknown,
-): value is Record<PropertyKey, unknown> => {
-  return typeof value === 'object' && value !== null;
-};
+// Fields that only ever appear on a normalized ConfigReturnType, never on
+// raw ConfigArgs (publicClient/walletClient/extendedConfig) — their presence
+// signals "this was meant to be a prebuilt config."
+const CONFIG_RETURN_TYPE_ONLY_KEYS = [
+  'chain',
+  'api',
+  'contractAddresses',
+  'contract',
+  'subgraph',
+  'rest',
+  'beacon',
+] as const;
 
 const hasIncompletePrebuiltConfigShape = (props: unknown): boolean => {
   if (!isNonNullObject(props)) {
     return false;
   }
 
-  return (
-    'publicClient' in props &&
-    'chain' in props &&
-    'api' in props &&
-    'contractAddresses' in props &&
-    'contract' in props &&
-    'subgraph' in props &&
-    'rest' in props &&
-    !('beacon' in props && isNonNullObject(props.beacon))
-  );
+  const looksPrebuilt = CONFIG_RETURN_TYPE_ONLY_KEYS.some((key) => key in props);
+
+  // isConfig validates every field's presence and shape symmetrically, so
+  // reuse it here instead of re-deriving which one field is broken — a
+  // prebuilt-looking object that fails isConfig for ANY reason (not just an
+  // invalid beacon) must not silently fall through to createConfig, which
+  // would rebuild everything from chain defaults and discard custom values.
+  return looksPrebuilt && !isConfig(props);
 };

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -75,6 +75,6 @@ const hasIncompletePrebuiltConfigShape = (props: unknown): boolean => {
     'contract' in props &&
     'subgraph' in props &&
     'rest' in props &&
-    !('beacon' in props)
+    !('beacon' in props && isNonNullObject(props.beacon))
   );
 };

--- a/src/utils/zod/config.ts
+++ b/src/utils/zod/config.ts
@@ -74,6 +74,11 @@ export const configArgsSchema = z
             endpoint: z.string().url().optional(),
           })
           .optional(),
+        beacon: z
+          .object({
+            endpoint: z.string().url().optional(),
+          })
+          .optional(),
         contracts: z
           .object({
             setter: z.string().optional(),
@@ -109,6 +114,9 @@ export type ConfigArgs = {
       apiKey?: string;
     };
     rest?: {
+      endpoint?: string;
+    };
+    beacon?: {
       endpoint?: string;
     };
     contracts?: {


### PR DESCRIPTION
## Summary

Adds a beacon client connector to the SDK with normalized validator reads and activation polling.

## Changes

- added `extendedConfig.beacon.endpoint`
- added beacon API methods for:
  - single validator reads
  - batch validator reads
  - normalized validator state reads
  - lifecycle stage derivation
  - activation polling
- normalized beacon validator responses into stable SDK shapes
- handled far-future beacon epoch sentinel values safely
- aligned batch validator reads with the standard Beacon API request shape
- added an empty-batch guard to avoid unfiltered validator list requests
- updated mocks, tests, and README

## Notes

Implemented against the standard Ethereum Beacon API.
Verified against a live Alchemy beacon endpoint and aligned with standard Beacon API provider docs.