### PR TITLE
chore: prepare 1.1.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 1.1.0 (2026-08-10)
+
+### Features
+
+- add a beacon chain client, exposed on `sdk.api` and configured via `extendedConfig.beacon.endpoint`
+- read validator state with `getBeaconValidator`, `getBeaconValidators`, `getBeaconValidatorState` and `getBeaconValidatorStates`
+- wait for activation with `waitForBeaconValidatorActivation`, and classify status with `getBeaconValidatorLifecycleStage`
+- report beacon failures as `BeaconHttpError` and `BeaconValidationError`, redacting credentials and query-string secrets from error messages
+
+### Fixes
+
+- reject incomplete prebuilt SDK configs instead of accepting a partially normalized object
+
+### Tests
+
+- add coverage for the beacon API, SDK initialization and the mock API
+
+### Docs
+
+- correct the `isConfig` comment to not overclaim nested validation
+
 # 1.0.2 (2026-05-21)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssv-labs/ssv-sdk",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "SSV.Labs",
   "description": "ssv labs sdk",
   "keywords": [


### PR DESCRIPTION
Release metadata for `1.1.0`. Same shape as #131: version bump plus a curated `CHANGELOG.md` entry, no source changes.

## Why 1.1.0 and not 1.0.3

`feat: add beacon client connector` (#132) adds public API surface — a beacon chain client on `sdk.api`, new exported readers, and the `extendedConfig.beacon.endpoint` option. That is a minor, not a patch.

## Why the changelog is short

The unreleased range (`v1.0.2..main`) is #132 and #133. It contains one `feat`, one unrelated `fix(config)`, one `docs`, and ~21 `fix(beacon):` commits. Those 21 are review rounds on the beacon feature *before it ever shipped*, so listing them as "Fixes" would describe fixes to a release that never existed. The user-visible ones — credential and query-string redaction in error messages — are folded into the feature description instead. This matches how the 1.0.2 entry was curated rather than dumped.

## After merge

1. Tag the merge commit of this PR: `git tag v1.1.0 <merge-sha> && git push origin v1.1.0` — lightweight, matching `v1.0.2`, which points at #131's merge commit.
2. `pnpm run v-pub-tarball` to check the tarball, then `npm publish`.

`dist/` is already current on `main` via #133 and carries no version string, so this bump produces no dist diff and will not open another `ci/update-artifacts` PR.
